### PR TITLE
Correct formatting in github alerts in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ analyze, and delete Gateway API and other Kubernetes resources. It also provides
 advanced features like visualizing relationships with DOT graphs and warning
 about potential issues.
 
-> [!NOTE] gwctl is still considered an [experimental feature of the Gateway
+> [!NOTE]
+> gwctl is still considered an [experimental feature of the Gateway
 > API](https://gateway-api.sigs.k8s.io/concepts/versioning/#release-channels-eg-experimental-standard).
 > While we iterate on the early stages of this tool, bugs and incompatible
 > changes will be more likely.


### PR DESCRIPTION
Correct formatting in [github alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) in README.md.

**AS-IS**

![image](https://github.com/user-attachments/assets/0aee6594-8cb4-48cd-93d5-c5aa8312661b)

**TO-BE**

![image](https://github.com/user-attachments/assets/2b2c6f4b-aa48-4234-8ffa-a88a5bf7db88)