### PR TITLE
Add dependabot configuration for Go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Dependencies listed in go.mod
+  - package-ecosystem: "gomod"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+      k8s.io: # Group k8s.io golang dependencies updates
+          patterns:
+            - "k8s.io/*"
+    labels:
+      - go
+      - dependencies
+      - ok-to-test


### PR DESCRIPTION
This commit introduces a Dependabot configuration file (`.github/dependabot.yml`) to automate dependency bumps. This will keep depedencies up to date and improve security by automatically checking for and creating PRs for new versions. Fixes #6 