### PR TITLE
fix: Make 'deps' a dependency for the 'test' Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean:
 	rm -rf $(BIN_DIR)
 
 .PHONY: test
-test:
+test: deps
 	go test -race -count=1 ./...
 
 .PHONY: verify


### PR DESCRIPTION
This should prevent test failures when dependabot sends PRs and the pull-gwctl-test fails due to inconsistent vendor

/assign @mlavacca 