### PR TITLE
Support for policies with multiple targetRefs

### DIFF
--- a/pkg/policymanager/merger.go
+++ b/pkg/policymanager/merger.go
@@ -22,7 +22,6 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	"sigs.k8s.io/gwctl/pkg/common"
 )
 
@@ -149,7 +148,7 @@ func mergePolicy(parent, child *Policy) (*Policy, error) {
 	result.Unstructured.SetUnstructuredContent(resultUnstructured)
 	// Merging two policies means the targetRef no longer makes any sense since
 	// since they can be conflicting. So we unset the targetRef.
-	result.TargetRef = common.GKNN{}
+	result.TargetRefs = []common.GKNN{}
 	return result, nil
 }
 

--- a/pkg/policymanager/merger_test.go
+++ b/pkg/policymanager/merger_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/gwctl/pkg/common"
 )
 
 func TestMergePoliciesOfSimilarKind(t *testing.T) {
@@ -139,6 +140,7 @@ func TestMergePoliciesOfSimilarKind(t *testing.T) {
 					},
 				},
 			},
+			TargetRefs:  []common.GKNN{},
 			Inheritable: true,
 		},
 		PolicyCrdID("TimeoutPolicy.bar.com"): {
@@ -159,6 +161,7 @@ func TestMergePoliciesOfSimilarKind(t *testing.T) {
 					},
 				},
 			},
+			TargetRefs: []common.GKNN{},
 		},
 	}
 

--- a/pkg/printer/policies.go
+++ b/pkg/printer/policies.go
@@ -36,7 +36,7 @@ func (p *TablePrinter) printPolicy(policyNode *topology.Node, w io.Writer) error
 
 	if p.table == nil {
 		p.table = &Table{
-			ColumnNames:  []string{"NAME", "KIND", "TARGET NAME", "TARGET KIND", "POLICY TYPE", "AGE"},
+			ColumnNames:  []string{"NAME", "KIND", "TARGET(S)", "POLICY TYPE", "AGE"},
 			UseSeparator: false,
 		}
 	}
@@ -63,8 +63,7 @@ func (p *TablePrinter) printPolicy(policyNode *topology.Node, w io.Writer) error
 	row := []string{
 		policy.Unstructured.GetName(),
 		kind,
-		policy.TargetRef.Name,
-		policy.TargetRef.Kind,
+		generatePolicyTargets(policy.TargetRefs),
 		policyType,
 		age,
 	}
@@ -183,4 +182,17 @@ func accessPolicyOrCRD[T any](node *topology.Node, gk schema.GroupKind) (*T, err
 		return nil, fmt.Errorf("unable to perform type assertion to %v in node %v", gk.String(), node.GKNN())
 	}
 	return data, nil
+}
+
+func generatePolicyTargets(targetRefs []common.GKNN) string {
+	switch len(targetRefs) {
+	case 0:
+		return ""
+	case 1:
+		return targetRefs[0].String()
+	case 2:
+		return fmt.Sprintf("%s, %s", targetRefs[0].String(), targetRefs[1].String())
+	default:
+		return fmt.Sprintf("%s, %s, ...", targetRefs[0].String(), targetRefs[1].String())
+	}
 }

--- a/pkg/printer/utils.go
+++ b/pkg/printer/utils.go
@@ -160,7 +160,7 @@ func convertPoliciesToRefsTable(policies []*policymanager.Policy, includeTarget 
 		UseSeparator: true,
 	}
 	if includeTarget {
-		table.ColumnNames = append(table.ColumnNames, "Target Kind", "Target Name")
+		table.ColumnNames = append(table.ColumnNames, "Target(s)")
 	}
 
 	for _, policy := range policies {
@@ -171,13 +171,6 @@ func convertPoliciesToRefsTable(policies []*policymanager.Policy, includeTarget 
 			policyName = fmt.Sprintf("%v/%v", ns, policyName)
 		}
 
-		targetKind := policy.TargetRef.Kind
-
-		targetName := policy.TargetRef.Name
-		if ns := policy.TargetRef.Namespace; ns != "" {
-			targetName = fmt.Sprintf("%v/%v", ns, targetName)
-		}
-
 		row := []string{
 			policyType, // Type
 			policyName, // Name
@@ -185,8 +178,7 @@ func convertPoliciesToRefsTable(policies []*policymanager.Policy, includeTarget 
 
 		if includeTarget {
 			row = append(row,
-				targetKind, // Target Kind
-				targetName, // Target Name
+				generatePolicyTargets(policy.TargetRefs),
 			)
 		}
 

--- a/test/integration/get_test.go
+++ b/test/integration/get_test.go
@@ -91,6 +91,25 @@ default    svc-3  Service  <unknown>
 `,
 		},
 		{
+			name:      "get policies",
+			inputArgs: []string{"policies"},
+			namespace: "test",
+			wantOut: `
+NAME      KIND                                        TARGET(S)                               POLICY TYPE  AGE
+policy-1  BackendTLSPolicy.gateway.networking.k8s.io  Service/test/svc-1, Service/test/svc-2  Direct       <unknown>
+`,
+		},
+		{
+			name:      "get policies -A",
+			inputArgs: []string{"policies", "-A"},
+			namespace: "", // All namespaces
+			wantOut: `
+NAME      KIND                                        TARGET(S)                               POLICY TYPE  AGE
+policy-2  BackendTLSPolicy.gateway.networking.k8s.io  Service/default/svc-3                   Direct       <unknown>
+policy-1  BackendTLSPolicy.gateway.networking.k8s.io  Service/test/svc-1, Service/test/svc-2  Direct       <unknown>
+`,
+		},
+		{
 			name:      "describe gateways -n test",
 			inputArgs: []string{"gateways"},
 			namespace: "test",

--- a/test/integration/testdata/sample1.yaml
+++ b/test/integration/testdata/sample1.yaml
@@ -186,6 +186,688 @@ spec:
     targetPort: 8080
 ---
 ################################################################################
+# BackendTLSPolicy
+################################################################################
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: backendtlspolicies.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+      - gateway-api
+    kind: BackendTLSPolicy
+    listKind: BackendTLSPolicyList
+    plural: backendtlspolicies
+    shortNames:
+      - btlspolicy
+    singular: backendtlspolicy
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          description: |-
+            BackendTLSPolicy provides a way to configure how a Gateway
+            connects to a Backend via TLS.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of BackendTLSPolicy.
+              properties:
+                options:
+                  additionalProperties:
+                    description: |-
+                      AnnotationValue is the value of an annotation in Gateway API. This is used
+                      for validation of maps such as TLS options. This roughly matches Kubernetes
+                      annotation validation, although the length validation in that case is based
+                      on the entire size of the annotations struct.
+                    maxLength: 4096
+                    minLength: 0
+                    type: string
+                  description: |-
+                    Options are a list of key/value pairs to enable extended TLS
+                    configuration for each implementation. For example, configuring the
+                    minimum TLS version or supported cipher suites.
+                    
+                    A set of common keys MAY be defined by the API in the future. To avoid
+                    any ambiguity, implementation-specific definitions MUST use
+                    domain-prefixed names, such as `example.com/my-custom-option`.
+                    Un-prefixed names are reserved for key names defined by Gateway API.
+                    
+                    Support: Implementation-specific
+                  maxProperties: 16
+                  type: object
+                targetRefs:
+                  description: |-
+                    TargetRefs identifies an API object to apply the policy to.
+                    Only Services have Extended support. Implementations MAY support
+                    additional objects, with Implementation Specific support.
+                    Note that this config applies to the entire referenced resource
+                    by default, but this default may change in the future to provide
+                    a more granular application of the policy.
+                    
+                    TargetRefs must be _distinct_. This means either that:
+                    
+                    * They select different targets. If this is the case, then targetRef
+                      entries are distinct. In terms of fields, this means that the
+                      multi-part key defined by `group`, `kind`, and `name` must
+                      be unique across all targetRef entries in the BackendTLSPolicy.
+                    * They select different sectionNames in the same target.
+                    
+                    Support: Extended for Kubernetes Service
+                    
+                    Support: Implementation-specific for any other resource
+                  items:
+                    description: |-
+                      LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                      direct policy to. This should be used as part of Policy resources that can
+                      target single resources. For more information on how this policy attachment
+                      mode works, and a sample Policy resource, refer to the policy attachment
+                      documentation for Gateway API.
+                      
+                      Note: This should only be used for direct policy attachment when references
+                      to SectionName are actually needed. In all other cases,
+                      LocalPolicyTargetReference should be used.
+                    properties:
+                      group:
+                        description: Group is the group of the target resource.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: Kind is kind of the target resource.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the target resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is the name of a section within the target resource. When
+                          unspecified, this targetRef targets the entire resource. In the following
+                          resources, SectionName is interpreted as the following:
+                          
+                          * Gateway: Listener name
+                          * HTTPRoute: HTTPRouteRule name
+                          * Service: Port name
+                          
+                          If a SectionName is specified, but does not exist on the targeted object,
+                          the Policy must fail to attach, and the policy implementation should record
+                          a `ResolvedRefs` or similar Condition in the Policy's status.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - group
+                      - kind
+                      - name
+                    type: object
+                  maxItems: 16
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: sectionName must be specified when targetRefs includes
+                        2 or more references to the same target
+                      rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name ? ((!has(p1.sectionName) || p1.sectionName
+                    == '''') == (!has(p2.sectionName) || p2.sectionName == ''''))
+                    : true))'
+                    - message: sectionName must be unique when targetRefs includes 2 or
+                        more references to the same target
+                      rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                        == p2.kind && p1.name == p2.name && (((!has(p1.sectionName) ||
+                        p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                        == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                        == p2.sectionName))))
+                validation:
+                  description: Validation contains backend TLS validation configuration.
+                  properties:
+                    caCertificateRefs:
+                      description: |-
+                        CACertificateRefs contains one or more references to Kubernetes objects that
+                        contain a PEM-encoded TLS CA certificate bundle, which is used to
+                        validate a TLS handshake between the Gateway and backend Pod.
+                        
+                        If CACertificateRefs is empty or unspecified, then WellKnownCACertificates must be
+                        specified. Only one of CACertificateRefs or WellKnownCACertificates may be specified,
+                        not both. If CACertificateRefs is empty or unspecified, the configuration for
+                        WellKnownCACertificates MUST be honored instead if supported by the implementation.
+                        
+                        References to a resource in a different namespace are invalid for the
+                        moment, although we will revisit this in the future.
+                        
+                        A single CACertificateRef to a Kubernetes ConfigMap kind has "Core" support.
+                        Implementations MAY choose to support attaching multiple certificates to
+                        a backend, but this behavior is implementation-specific.
+                        
+                        Support: Core - An optional single reference to a Kubernetes ConfigMap,
+                        with the CA certificate in a key named `ca.crt`.
+                        
+                        Support: Implementation-specific (More than one reference, or other kinds
+                        of resources).
+                      items:
+                        description: |-
+                          LocalObjectReference identifies an API object within the namespace of the
+                          referrer.
+                          The API object must be valid in the cluster; the Group and Kind must
+                          be registered in the cluster for this reference to be valid.
+                          
+                          References to objects with invalid Group and Kind are not valid, and must
+                          be rejected by the implementation, with appropriate Conditions set
+                          on the containing object.
+                        properties:
+                          group:
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is kind of the referent. For example "HTTPRoute"
+                              or "Service".
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        required:
+                          - group
+                          - kind
+                          - name
+                        type: object
+                      maxItems: 8
+                      type: array
+                    hostname:
+                      description: |-
+                        Hostname is used for two purposes in the connection between Gateways and
+                        backends:
+                        
+                        1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
+                        2. Hostname MUST be used for authentication and MUST match the certificate served by the matching backend, unless SubjectAltNames is specified.
+                           authentication and MUST match the certificate served by the matching
+                           backend.
+                        
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    subjectAltNames:
+                      description: |-
+                        SubjectAltNames contains one or more Subject Alternative Names.
+                        When specified the certificate served from the backend MUST
+                        have at least one Subject Alternate Name matching one of the specified SubjectAltNames.
+                        
+                        Support: Extended
+                      items:
+                        description: SubjectAltName represents Subject Alternative Name.
+                        properties:
+                          hostname:
+                            description: |-
+                              Hostname contains Subject Alternative Name specified in DNS name format.
+                              Required when Type is set to Hostname, ignored otherwise.
+                              
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          type:
+                            description: |-
+                              Type determines the format of the Subject Alternative Name. Always required.
+                              
+                              Support: Core
+                            enum:
+                              - Hostname
+                              - URI
+                            type: string
+                          uri:
+                            description: |-
+                              URI contains Subject Alternative Name specified in a full URI format.
+                              It MUST include both a scheme (e.g., "http" or "ftp") and a scheme-specific-part.
+                              Common values include SPIFFE IDs like "spiffe://mycluster.example.com/ns/myns/sa/svc1sa".
+                              Required when Type is set to URI, ignored otherwise.
+                              
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                            type: string
+                        required:
+                          - type
+                        type: object
+                        x-kubernetes-validations:
+                          - message: SubjectAltName element must contain Hostname, if
+                              Type is set to Hostname
+                            rule: '!(self.type == "Hostname" && (!has(self.hostname) ||
+                          self.hostname == ""))'
+                          - message: SubjectAltName element must not contain Hostname,
+                              if Type is not set to Hostname
+                            rule: '!(self.type != "Hostname" && has(self.hostname) &&
+                          self.hostname != "")'
+                          - message: SubjectAltName element must contain URI, if Type
+                              is set to URI
+                            rule: '!(self.type == "URI" && (!has(self.uri) || self.uri
+                          == ""))'
+                          - message: SubjectAltName element must not contain URI, if Type
+                              is not set to URI
+                            rule: '!(self.type != "URI" && has(self.uri) && self.uri !=
+                          "")'
+                      maxItems: 5
+                      type: array
+                    wellKnownCACertificates:
+                      description: |-
+                        WellKnownCACertificates specifies whether system CA certificates may be used in
+                        the TLS handshake between the gateway and backend pod.
+                        
+                        If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
+                        must be specified with at least one entry for a valid configuration. Only one of
+                        CACertificateRefs or WellKnownCACertificates may be specified, not both. If an
+                        implementation does not support the WellKnownCACertificates field or the value
+                        supplied is not supported, the Status Conditions on the Policy MUST be
+                        updated to include an Accepted: False Condition with Reason: Invalid.
+                        
+                        Support: Implementation-specific
+                      enum:
+                        - System
+                      type: string
+                  required:
+                    - hostname
+                  type: object
+                  x-kubernetes-validations:
+                    - message: must not contain both CACertificateRefs and WellKnownCACertificates
+                      rule: '!(has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 && has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")'
+                    - message: must specify either CACertificateRefs or WellKnownCACertificates
+                      rule: (has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                        > 0 || has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                        != "")
+              required:
+                - targetRefs
+                - validation
+              type: object
+            status:
+              description: Status defines the current state of BackendTLSPolicy.
+              properties:
+                ancestors:
+                  description: |-
+                    Ancestors is a list of ancestor resources (usually Gateways) that are
+                    associated with the policy, and the status of the policy with respect to
+                    each ancestor. When this policy attaches to a parent, the controller that
+                    manages the parent and the ancestors MUST add an entry to this list when
+                    the controller first sees the policy and SHOULD update the entry as
+                    appropriate when the relevant ancestor is modified.
+                    
+                    Note that choosing the relevant ancestor is left to the Policy designers;
+                    an important part of Policy design is designing the right object level at
+                    which to namespace this status.
+                    
+                    Note also that implementations MUST ONLY populate ancestor status for
+                    the Ancestor resources they are responsible for. Implementations MUST
+                    use the ControllerName field to uniquely identify the entries in this list
+                    that they are responsible for.
+                    
+                    Note that to achieve this, the list of PolicyAncestorStatus structs
+                    MUST be treated as a map with a composite key, made up of the AncestorRef
+                    and ControllerName fields combined.
+                    
+                    A maximum of 16 ancestors will be represented in this list. An empty list
+                    means the Policy is not relevant for any ancestors.
+                    
+                    If this slice is full, implementations MUST NOT add further entries.
+                    Instead they MUST consider the policy unimplementable and signal that
+                    on any related resources such as the ancestor that would be referenced
+                    here. For example, if this list was full on BackendTLSPolicy, no
+                    additional Gateways would be able to reference the Service targeted by
+                    the BackendTLSPolicy.
+                  items:
+                    description: |-
+                      PolicyAncestorStatus describes the status of a route with respect to an
+                      associated Ancestor.
+                      
+                      Ancestors refer to objects that are either the Target of a policy or above it
+                      in terms of object hierarchy. For example, if a policy targets a Service, the
+                      Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                      the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                      useful object to place Policy status on, so we recommend that implementations
+                      SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                      have a _very_ good reason otherwise.
+                      
+                      In the context of policy attachment, the Ancestor is used to distinguish which
+                      resource results in a distinct application of this policy. For example, if a policy
+                      targets a Service, it may have a distinct result per attached Gateway.
+                      
+                      Policies targeting the same resource may have different effects depending on the
+                      ancestors of those resources. For example, different Gateways targeting the same
+                      Service may have different capabilities, especially if they have different underlying
+                      implementations.
+                      
+                      For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                      used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                      In this case, the relevant object for status is the Gateway, and that is the
+                      ancestor object referred to in this status.
+                      
+                      Note that a parent is also an ancestor, so for objects where the parent is the
+                      relevant object for status, this struct SHOULD still be used.
+                      
+                      This struct is intended to be used in a slice that's effectively a map,
+                      with a composite key made up of the AncestorRef and the ControllerName.
+                    properties:
+                      ancestorRef:
+                        description: |-
+                          AncestorRef corresponds with a ParentRef in the spec that this
+                          PolicyAncestorStatus struct describes the status of.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: |-
+                              Group is the group of the referent.
+                              When unspecified, "gateway.networking.k8s.io" is inferred.
+                              To set the core API group (such as for a "Service" kind referent),
+                              Group must be explicitly set to "" (empty string).
+                              
+                              Support: Core
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Gateway
+                            description: |-
+                              Kind is kind of the referent.
+                              
+                              There are two kinds of parent resources with "Core" support:
+                              
+                              * Gateway (Gateway conformance profile)
+                              * Service (Mesh conformance profile, ClusterIP Services only)
+                              
+                              Support for other resources is Implementation-Specific.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the referent.
+                              
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the referent. When unspecified, this refers
+                              to the local namespace of the Route.
+                              
+                              Note that there are specific rules for ParentRefs which cross namespace
+                              boundaries. Cross-namespace references are only valid if they are explicitly
+                              allowed by something in the namespace they are referring to. For example:
+                              Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                              generic way to enable any other kind of cross-namespace reference.
+                              
+                              
+                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                              routes, which apply default routing rules to inbound connections from
+                              any namespace to the Service.
+                              
+                              ParentRefs from a Route to a Service in a different namespace are
+                              "consumer" routes, and these routing rules are only applied to outbound
+                              connections originating from the same namespace as the Route, for which
+                              the intended destination of the connections are a Service targeted as a
+                              ParentRef of the Route.
+                              
+                              
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port is the network port this Route targets. It can be interpreted
+                              differently based on the type of parent resource.
+                              
+                              When the parent resource is a Gateway, this targets all listeners
+                              listening on the specified port that also support this kind of Route(and
+                              select this Route). It's not recommended to set `Port` unless the
+                              networking behaviors specified in a Route must apply to a specific port
+                              as opposed to a listener(s) whose port(s) may be changed. When both Port
+                              and SectionName are specified, the name and port of the selected listener
+                              must match both specified values.
+                              
+                              
+                              When the parent resource is a Service, this targets a specific port in the
+                              Service spec. When both Port (experimental) and SectionName are specified,
+                              the name and port of the selected port must match both specified values.
+                              
+                              
+                              Implementations MAY choose to support other parent resources.
+                              Implementations supporting other types of parent resources MUST clearly
+                              document how/if Port is interpreted.
+                              
+                              For the purpose of status, an attachment is considered successful as
+                              long as the parent resource accepts it partially. For example, Gateway
+                              listeners can restrict which Routes can attach to them by Route kind,
+                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                              from the referencing Route, the Route MUST be considered successfully
+                              attached. If no Gateway listeners accept attachment from this Route,
+                              the Route MUST be considered detached from the Gateway.
+                              
+                              Support: Extended
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          sectionName:
+                            description: |-
+                              SectionName is the name of a section within the target resource. In the
+                              following resources, SectionName is interpreted as the following:
+                              
+                              * Gateway: Listener name. When both Port (experimental) and SectionName
+                              are specified, the name and port of the selected listener must match
+                              both specified values.
+                              * Service: Port name. When both Port (experimental) and SectionName
+                              are specified, the name and port of the selected listener must match
+                              both specified values.
+                              
+                              Implementations MAY choose to support attaching Routes to other resources.
+                              If that is the case, they MUST clearly document how SectionName is
+                              interpreted.
+                              
+                              When unspecified (empty string), this will reference the entire resource.
+                              For the purpose of status, an attachment is considered successful if at
+                              least one section in the parent resource accepts it. For example, Gateway
+                              listeners can restrict which Routes can attach to them by Route kind,
+                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                              the referencing Route, the Route MUST be considered successfully
+                              attached. If no Gateway listeners accept attachment from this Route, the
+                              Route MUST be considered detached from the Gateway.
+                              
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      conditions:
+                        description: Conditions describes the status of the Policy with
+                          respect to the given Ancestor.
+                        items:
+                          description: Condition contains details for one aspect of
+                            the current state of this API Resource.
+                          properties:
+                            lastTransitionTime:
+                              description: |-
+                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              format: date-time
+                              type: string
+                            message:
+                              description: |-
+                                message is a human readable message indicating details about the transition.
+                                This may be an empty string.
+                              maxLength: 32768
+                              type: string
+                            observedGeneration:
+                              description: |-
+                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                with respect to the current state of the instance.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            reason:
+                              description: |-
+                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                Producers of specific condition types may define expected values and meanings for this field,
+                                and whether the values are considered a guaranteed API.
+                                The value should be a CamelCase string.
+                                This field may not be empty.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        maxItems: 8
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      controllerName:
+                        description: |-
+                          ControllerName is a domain/path string that indicates the name of the
+                          controller that wrote this status. This corresponds with the
+                          controllerName field on GatewayClass.
+                          
+                          Example: "example.net/gateway-controller".
+                          
+                          The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                          valid Kubernetes names
+                          (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                          
+                          Controllers MUST populate this field when writing status. Controllers should ensure that
+                          entries to status populated with their ControllerName are cleaned up when they are no
+                          longer necessary.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                        type: string
+                    required:
+                      - ancestorRef
+                      - controllerName
+                    type: object
+                  maxItems: 16
+                  type: array
+              required:
+                - ancestors
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: policy-1
+  namespace: test
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name:  svc-1
+    - group: ""
+      kind: Service
+      name: svc-2
+  validation:
+    hostname: example.com
+    wellKnownCACertificates: System
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: policy-2
+  namespace: default
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name:  svc-3
+  validation:
+    hostname: example.com
+    wellKnownCACertificates: System
+---
+################################################################################
 # Events
 ################################################################################
 apiVersion: v1


### PR DESCRIPTION
Until now, `gwctl` has only supported a single `targetRef` per policy. However many policies, e.g., `BackendTLSPolicy`,allow a multiple targets specified in a `targetRefs` list. This PR adds support for multiple targets.

Fixes: #1