### PR TITLE
chore: Enhance .gitignore to exclude editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
 bin/
-vendor/
-.vscode/
 dist/
+vendor/
+
+.DS_Store
+
+.idea/
+*.iml
+.vscode/
+*.swp
+*.sublime-project
+*.sublime-workspace
+*~


### PR DESCRIPTION
This PR enhances the `.gitignore` rules by adding common build outputs and IDE/editor-specific files, ensuring that generated or personal workspace files aren’t accidentally committed.