### PR TITLE
fix: Add a nil check for httpRouteNodeMetadata before accessing its fields

### DIFF
--- a/pkg/extension/gatewayeffectivepolicy/gatewayeffectivepolicy.go
+++ b/pkg/extension/gatewayeffectivepolicy/gatewayeffectivepolicy.go
@@ -406,6 +406,10 @@ func (a *Extension) calculateEffectivePoliciesForBackends(graph *topology.Graph)
 			if err != nil {
 				return err
 			}
+			if httpRouteNodeMetadata == nil {
+				klog.V(3).InfoS("No effective policy metadata found for HTTPRoute, skipping", "httpRoute", httpRouteNode.GKNN())
+				continue
+			}
 			httpRoutePoliciesByGateway := httpRouteNodeMetadata.HTTPRouteEffectivePolicies
 
 			for gatewayID, policies := range httpRoutePoliciesByGateway {


### PR DESCRIPTION
Fixes: #59 

Add a nil check for httpRouteNodeMetadata before accessing its fields to fix invalid memory address or nil pointer dereference error when HTTPRoute node does not have effective policy metadata.

/cc @gauravkghildiyal