### PR TITLE
feat: NAMESPACE and ACCEPTED column added to get policies output

### DIFF
--- a/pkg/policymanager/manager.go
+++ b/pkg/policymanager/manager.go
@@ -170,6 +170,8 @@ type Policy struct {
 	// Indicates whether the policy is supposed to be "inherited" (as opposed to
 	// "direct").
 	Inheritable bool
+
+	Status gatewayv1.PolicyStatus
 }
 
 func ConstructPolicy(u *unstructured.Unstructured, inherited bool) (Policy, error) {
@@ -183,6 +185,7 @@ func ConstructPolicy(u *unstructured.Unstructured, inherited bool) (Policy, erro
 			TargetRef  gatewayv1.NamespacedPolicyTargetReference   `json:"targetRef,omitempty"`
 			TargetRefs []gatewayv1.NamespacedPolicyTargetReference `json:"targetRefs,omitempty"`
 		} `json:"spec"`
+		Status gatewayv1.PolicyStatus `json:"status,omitempty"`
 	}
 	structuredPolicy := &genericPolicy{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), structuredPolicy); err != nil {
@@ -211,6 +214,8 @@ func ConstructPolicy(u *unstructured.Unstructured, inherited bool) (Policy, erro
 	}
 
 	result.Inheritable = inherited
+
+	result.Status = structuredPolicy.Status
 
 	return result, nil
 }

--- a/test/integration/get_test.go
+++ b/test/integration/get_test.go
@@ -95,8 +95,8 @@ default    svc-3  Service  <unknown>
 			inputArgs: []string{"policies"},
 			namespace: "test",
 			wantOut: `
-NAME      KIND                                        TARGET(S)                               POLICY TYPE  AGE
-policy-1  BackendTLSPolicy.gateway.networking.k8s.io  Service/test/svc-1, Service/test/svc-2  Direct       <unknown>
+NAMESPACE  NAME      KIND                                        TARGET(S)                               POLICY TYPE  ACCEPTED  AGE
+test       policy-1  BackendTLSPolicy.gateway.networking.k8s.io  Service/test/svc-1, Service/test/svc-2  Direct       True      <unknown>
 `,
 		},
 		{
@@ -104,9 +104,9 @@ policy-1  BackendTLSPolicy.gateway.networking.k8s.io  Service/test/svc-1, Servic
 			inputArgs: []string{"policies", "-A"},
 			namespace: "", // All namespaces
 			wantOut: `
-NAME      KIND                                        TARGET(S)                               POLICY TYPE  AGE
-policy-2  BackendTLSPolicy.gateway.networking.k8s.io  Service/default/svc-3                   Direct       <unknown>
-policy-1  BackendTLSPolicy.gateway.networking.k8s.io  Service/test/svc-1, Service/test/svc-2  Direct       <unknown>
+NAMESPACE  NAME      KIND                                        TARGET(S)                               POLICY TYPE  ACCEPTED  AGE
+default    policy-2  BackendTLSPolicy.gateway.networking.k8s.io  Service/default/svc-3                   Direct       Partial   <unknown>
+test       policy-1  BackendTLSPolicy.gateway.networking.k8s.io  Service/test/svc-1, Service/test/svc-2  Direct       True      <unknown>
 `,
 		},
 		{

--- a/test/integration/testdata/sample1.yaml
+++ b/test/integration/testdata/sample1.yaml
@@ -1523,6 +1523,19 @@ spec:
   validation:
     hostname: example.com
     wellKnownCACertificates: System
+status:
+  ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: test
+      controllerName: foo.com/external-gateway-class
+      conditions:
+        - type: Accepted
+          status: "True"
+          reason: Accepted
+          message: BackendTLSPolicy is accepted
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
@@ -1537,6 +1550,30 @@ spec:
   validation:
     hostname: example.com
     wellKnownCACertificates: System
+status:
+  ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: test
+      controllerName: foo.com/external-gateway-class
+      conditions:
+        - type: Accepted
+          status: "False"
+          reason: Invalid
+          message: BackendTLSPolicy is invalid
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-2
+        namespace: default
+      controllerName: bar.baz/internal-gateway-class
+      conditions:
+        - type: Accepted
+          status: "True"
+          reason: Accepted
+          message: BackendTLSPolicy is accepted
 ---
 ################################################################################
 # Events


### PR DESCRIPTION
This PR enhances `gwctl get policies` by adding the missing `NAMESPACE` column and introducing a `ACCEPTED` column that aggregates the Accepted condition from all PolicyAncestorStatus entries.