### PR TITLE
Omit `NAMESPACE` column when querying resources in a single namespace

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -251,10 +251,11 @@ func (o *getOptions) handlePolicy(args []string) error {
 
 func (o *getOptions) printNodes(nodes []*topology.Node) error {
 	printerOptions := printer.PrinterOptions{
-		OutputFormat: o.output,
-		Clock:        clock.RealClock{},
-		Description:  o.isDescribe,
-		EventFetcher: printer.NewDefaultEventFetcher(o.factory),
+		OutputFormat:  o.output,
+		Clock:         clock.RealClock{},
+		Description:   o.isDescribe,
+		EventFetcher:  printer.NewDefaultEventFetcher(o.factory),
+		AllNamespaces: o.allNamespaces,
 	}
 	p := printer.NewPrinter(printerOptions)
 	defer p.Flush(o.Out)

--- a/pkg/printer/backends.go
+++ b/pkg/printer/backends.go
@@ -39,11 +39,10 @@ func (p *TablePrinter) printBackend(backendNode *topology.Node, w io.Writer) err
 	}
 
 	if p.table == nil {
-		var columnNames []string
+		columnNames := namespacedBaseColumnNames(p.AllNamespaces)
+		columnNames = append(columnNames, "TYPE", "AGE")
 		if p.OutputFormat == OutputFormatWide {
-			columnNames = []string{"NAMESPACE", "NAME", "TYPE", "AGE", "REFERRED BY ROUTES", "POLICIES"}
-		} else {
-			columnNames = []string{"NAMESPACE", "NAME", "TYPE", "AGE"}
+			columnNames = append(columnNames, "REFERRED BY ROUTES", "POLICIES")
 		}
 		p.table = &Table{
 			ColumnNames:  columnNames,
@@ -52,9 +51,6 @@ func (p *TablePrinter) printBackend(backendNode *topology.Node, w io.Writer) err
 	}
 
 	backend := backendNode.Object
-
-	namespace := backend.GetNamespace()
-	name := backend.GetName()
 	backendType := backend.GetKind()
 
 	age := "<unknown>"
@@ -63,12 +59,7 @@ func (p *TablePrinter) printBackend(backendNode *topology.Node, w io.Writer) err
 		age = duration.HumanDuration(p.Clock.Since(creationTimestamp.Time))
 	}
 
-	row := []string{
-		namespace,
-		name,
-		backendType,
-		age,
-	}
+	row := append(rowPrefixNamespaced(backend, p.AllNamespaces), backendType, age)
 	if p.OutputFormat == OutputFormatWide {
 		httpRouteNodes := maps.Values(topologygw.BackendNode(backendNode).HTTPRoutes())
 		sortedHTTPRouteNodes := topology.SortedNodes(httpRouteNodes)

--- a/pkg/printer/backends_test.go
+++ b/pkg/printer/backends_test.go
@@ -27,24 +27,48 @@ import (
 )
 
 func TestTablePrinter_printBackend(t *testing.T) {
-	options := PrinterOptions{}
-	p := &TablePrinter{PrinterOptions: options}
-	out := &bytes.Buffer{}
-
-	for _, ns := range testData(t)[common.ServiceGK] {
-		p.printBackend(ns, out)
-		p.Flush(out)
-	}
-
-	wantOut := `
+	tests := []struct {
+		name    string
+		options PrinterOptions
+		wantOut string
+	}{
+		{
+			name:    "default",
+			options: PrinterOptions{},
+			wantOut: `
+NAME   TYPE     AGE
+svc-1  Service  <unknown>
+`,
+		},
+		{
+			name: "all namespaces",
+			options: PrinterOptions{
+				AllNamespaces: true,
+			},
+			wantOut: `
 NAMESPACE  NAME   TYPE     AGE
 ns-1       svc-1  Service  <unknown>
-`
+`,
+		},
+	}
 
-	got := common.MultiLine(out.String())
-	want := common.MultiLine(strings.TrimPrefix(wantOut, "\n"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &TablePrinter{PrinterOptions: tt.options}
+			out := &bytes.Buffer{}
 
-	if diff := cmp.Diff(want, got, common.MultiLineTransformer); diff != "" {
-		t.Fatalf("Unexpected diff:\n\ngot =\n\n%v\n\nwant =\n\n%v\n\ndiff (-want, +got) =\n\n%v", got, want, common.MultiLine(diff))
+			for _, ns := range testData(t)[common.ServiceGK] {
+				p.printBackend(ns, out)
+				p.Flush(out)
+			}
+
+			got := common.MultiLine(out.String())
+			want := common.MultiLine(strings.TrimPrefix(tt.wantOut, "\n"))
+
+			if diff := cmp.Diff(want, got, common.MultiLineTransformer); diff != "" {
+				t.Fatalf("Unexpected diff:\n\ngot =\n\n%v\n\nwant =\n\n%v\n\ndiff (-want, +got) =\n\n%v",
+					got, want, common.MultiLine(diff))
+			}
+		})
 	}
 }

--- a/pkg/printer/gateways.go
+++ b/pkg/printer/gateways.go
@@ -40,11 +40,10 @@ func (p *TablePrinter) printGateway(gatewayNode *topology.Node, w io.Writer) err
 	}
 
 	if p.table == nil {
-		var columnNames []string
+		columnNames := namespacedBaseColumnNames(p.AllNamespaces)
+		columnNames = append(columnNames, "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE")
 		if p.OutputFormat == OutputFormatWide {
-			columnNames = []string{"NAMESPACE", "NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE", "POLICIES", "HTTPROUTES"}
-		} else {
-			columnNames = []string{"NAMESPACE", "NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE"}
+			columnNames = append(columnNames, "POLICIES", "HTTPROUTES")
 		}
 		p.table = &Table{
 			ColumnNames:  columnNames,
@@ -83,15 +82,7 @@ func (p *TablePrinter) printGateway(gatewayNode *topology.Node, w io.Writer) err
 		age = duration.HumanDuration(p.Clock.Since(creationTimestamp.Time))
 	}
 
-	row := []string{
-		gateway.GetNamespace(),
-		gateway.GetName(),
-		string(gateway.Spec.GatewayClassName),
-		addressesOutput,
-		portsOutput,
-		programmedStatus,
-		age,
-	}
+	row := append(rowPrefixNamespaced(gateway, p.AllNamespaces), string(gateway.Spec.GatewayClassName), addressesOutput, portsOutput, programmedStatus, age)
 	if p.OutputFormat == OutputFormatWide {
 		policiesMap, err := directlyattachedpolicy.Access(gatewayNode)
 		if err != nil {

--- a/pkg/printer/gateways_test.go
+++ b/pkg/printer/gateways_test.go
@@ -27,24 +27,48 @@ import (
 )
 
 func TestTablePrinter_printGateway(t *testing.T) {
-	options := PrinterOptions{}
-	p := &TablePrinter{PrinterOptions: options}
-	out := &bytes.Buffer{}
-
-	for _, ns := range testData(t)[common.GatewayGK] {
-		p.printGateway(ns, out)
-		p.Flush(out)
-	}
-
-	wantOut := `
+	tests := []struct {
+		name    string
+		options PrinterOptions
+		wantOut string
+	}{
+		{
+			name:    "default",
+			options: PrinterOptions{},
+			wantOut: `
+NAME       CLASS            ADDRESSES                   PORTS  PROGRAMMED  AGE
+gateway-1  gateway-class-1  10.0.0.1,10.0.0.2 + 1 more  80     True        <unknown>
+`,
+		},
+		{
+			name: "all namespaces",
+			options: PrinterOptions{
+				AllNamespaces: true,
+			},
+			wantOut: `
 NAMESPACE  NAME       CLASS            ADDRESSES                   PORTS  PROGRAMMED  AGE
 ns-1       gateway-1  gateway-class-1  10.0.0.1,10.0.0.2 + 1 more  80     True        <unknown>
-`
+`,
+		},
+	}
 
-	got := common.MultiLine(out.String())
-	want := common.MultiLine(strings.TrimPrefix(wantOut, "\n"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &TablePrinter{PrinterOptions: tt.options}
+			out := &bytes.Buffer{}
 
-	if diff := cmp.Diff(want, got, common.MultiLineTransformer); diff != "" {
-		t.Fatalf("Unexpected diff:\n\ngot =\n\n%v\n\nwant =\n\n%v\n\ndiff (-want, +got) =\n\n%v", got, want, common.MultiLine(diff))
+			for _, ns := range testData(t)[common.GatewayGK] {
+				p.printGateway(ns, out)
+				p.Flush(out)
+			}
+
+			got := common.MultiLine(out.String())
+			want := common.MultiLine(strings.TrimPrefix(tt.wantOut, "\n"))
+
+			if diff := cmp.Diff(want, got, common.MultiLineTransformer); diff != "" {
+				t.Fatalf("Unexpected diff:\n\ngot =\n\n%v\n\nwant =\n\n%v\n\ndiff (-want, +got) =\n\n%v",
+					got, want, common.MultiLine(diff))
+			}
+		})
 	}
 }

--- a/pkg/printer/httproutes.go
+++ b/pkg/printer/httproutes.go
@@ -38,13 +38,11 @@ func (p *TablePrinter) printHTTPRoute(httpRouteNode *topology.Node, w io.Writer)
 	}
 
 	if p.table == nil {
-		var columnNames []string
+		columnNames := namespacedBaseColumnNames(p.AllNamespaces)
+		columnNames = append(columnNames, "HOSTNAMES", "PARENT REFS", "ACCEPTED", "RESOLVED", "AGE")
 		if p.OutputFormat == OutputFormatWide {
-			columnNames = []string{"NAMESPACE", "NAME", "HOSTNAMES", "PARENT REFS", "ACCEPTED", "RESOLVED", "AGE", "POLICIES"}
-		} else {
-			columnNames = []string{"NAMESPACE", "NAME", "HOSTNAMES", "PARENT REFS", "ACCEPTED", "RESOLVED", "AGE"}
+			columnNames = append(columnNames, "POLICIES")
 		}
-
 		p.table = &Table{
 			ColumnNames:  columnNames,
 			UseSeparator: false,
@@ -123,15 +121,7 @@ func (p *TablePrinter) printHTTPRoute(httpRouteNode *topology.Node, w io.Writer)
 		age = duration.HumanDuration(p.Clock.Since(creationTimestamp.Time))
 	}
 
-	row := []string{
-		httpRoute.GetNamespace(),
-		httpRoute.GetName(),
-		hostNamesOutput,
-		parentRefsCount,
-		acceptedStatus,
-		resolvedStatus,
-		age,
-	}
+	row := append(rowPrefixNamespaced(httpRoute, p.AllNamespaces), hostNamesOutput, parentRefsCount, acceptedStatus, resolvedStatus, age)
 	if p.OutputFormat == OutputFormatWide {
 		policiesMap, err := directlyattachedpolicy.Access(httpRouteNode)
 		if err != nil {

--- a/pkg/printer/policies.go
+++ b/pkg/printer/policies.go
@@ -36,7 +36,7 @@ func (p *TablePrinter) printPolicy(policyNode *topology.Node, w io.Writer) error
 
 	if p.table == nil {
 		p.table = &Table{
-			ColumnNames:  []string{"NAMESPACE", "NAME", "KIND", "TARGET(S)", "POLICY TYPE", "ACCEPTED", "AGE"},
+			ColumnNames:  append(namespacedBaseColumnNames(p.AllNamespaces), "KIND", "TARGET(S)", "POLICY TYPE", "ACCEPTED", "AGE"),
 			UseSeparator: false,
 		}
 	}
@@ -85,15 +85,7 @@ func (p *TablePrinter) printPolicy(policyNode *topology.Node, w io.Writer) error
 		age = duration.HumanDuration(p.Clock.Since(creationTimestamp.Time))
 	}
 
-	row := []string{
-		policy.Unstructured.GetNamespace(),
-		policy.Unstructured.GetName(),
-		kind,
-		generatePolicyTargets(policy.TargetRefs),
-		policyType,
-		acceptedStatus,
-		age,
-	}
+	row := append(rowPrefixNamespaced(policy.Unstructured, p.AllNamespaces), kind, generatePolicyTargets(policy.TargetRefs), policyType, acceptedStatus, age)
 	p.table.Rows = append(p.table.Rows, row)
 
 	return nil

--- a/pkg/printer/policies_test.go
+++ b/pkg/printer/policies_test.go
@@ -27,24 +27,48 @@ import (
 )
 
 func TestTablePrinter_printPolicy(t *testing.T) {
-	options := PrinterOptions{}
-	p := &TablePrinter{PrinterOptions: options}
-	out := &bytes.Buffer{}
-
-	for _, ns := range testPoliciesData(t)[common.PolicyGK] {
-		p.printBackend(ns, out)
-		p.Flush(out)
-	}
-
-	wantOut := `
+	tests := []struct {
+		name    string
+		options PrinterOptions
+		wantOut string
+	}{
+		{
+			name:    "default",
+			options: PrinterOptions{},
+			wantOut: `
+NAME      TYPE           AGE
+policy-1  TimeoutPolicy  <unknown>
+`,
+		},
+		{
+			name: "all namespaces",
+			options: PrinterOptions{
+				AllNamespaces: true,
+			},
+			wantOut: `
 NAMESPACE  NAME      TYPE           AGE
 ns-1       policy-1  TimeoutPolicy  <unknown>
-`
+`,
+		},
+	}
 
-	got := common.MultiLine(out.String())
-	want := common.MultiLine(strings.TrimPrefix(wantOut, "\n"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &TablePrinter{PrinterOptions: tt.options}
+			out := &bytes.Buffer{}
 
-	if diff := cmp.Diff(want, got, common.MultiLineTransformer); diff != "" {
-		t.Fatalf("Unexpected diff:\n\ngot =\n\n%v\n\nwant =\n\n%v\n\ndiff (-want, +got) =\n\n%v", got, want, common.MultiLine(diff))
+			for _, ns := range testPoliciesData(t)[common.PolicyGK] {
+				p.printBackend(ns, out)
+				p.Flush(out)
+			}
+
+			got := common.MultiLine(out.String())
+			want := common.MultiLine(strings.TrimPrefix(tt.wantOut, "\n"))
+
+			if diff := cmp.Diff(want, got, common.MultiLineTransformer); diff != "" {
+				t.Fatalf("Unexpected diff:\n\ngot =\n\n%v\n\nwant =\n\n%v\n\ndiff (-want, +got) =\n\n%v",
+					got, want, common.MultiLine(diff))
+			}
+		})
 	}
 }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -60,10 +60,11 @@ func AllowedOutputFormatsForHelp() []string {
 }
 
 type PrinterOptions struct { //nolint:revive
-	OutputFormat OutputFormat
-	Description  bool
-	Clock        clock.Clock
-	EventFetcher eventFetcher
+	OutputFormat  OutputFormat
+	Description   bool
+	Clock         clock.Clock
+	EventFetcher  eventFetcher
+	AllNamespaces bool
 }
 
 type Printer interface {

--- a/pkg/printer/utils.go
+++ b/pkg/printer/utils.go
@@ -24,6 +24,7 @@ import (
 	"text/tabwriter"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -129,6 +130,20 @@ func (t *Table) indentRow(row []string, indent int) []string {
 	newRow := append([]string{}, row...)
 	newRow[0] = fmt.Sprintf("%s%s", strings.Repeat(" ", indent), newRow[0])
 	return newRow
+}
+
+func namespacedBaseColumnNames(allNamespaces bool) []string {
+	if allNamespaces {
+		return []string{"NAMESPACE", "NAME"}
+	}
+	return []string{"NAME"}
+}
+
+func rowPrefixNamespaced(obj metav1.Object, allNamespaces bool) []string {
+	if allNamespaces {
+		return []string{obj.GetNamespace(), obj.GetName()}
+	}
+	return []string{obj.GetName()}
 }
 
 func convertEventsSliceToTable(events []*corev1.Event, clock clock.Clock) *Table {

--- a/test/integration/get_test.go
+++ b/test/integration/get_test.go
@@ -47,9 +47,9 @@ func TestGet(t *testing.T) {
 			inputArgs: []string{"gateways"},
 			namespace: "test",
 			wantOut: `
-NAMESPACE  NAME       CLASS                           ADDRESSES  PORTS  PROGRAMMED  AGE
-test       gateway-1  foo-com-external-gateway-class             80     Unknown     <unknown>
-test       gateway-2  bar-com-internal-gateway-class             443    Unknown     <unknown>
+NAME       CLASS                           ADDRESSES  PORTS  PROGRAMMED  AGE
+gateway-1  foo-com-external-gateway-class             80     Unknown     <unknown>
+gateway-2  bar-com-internal-gateway-class             443    Unknown     <unknown>
 `,
 		},
 		{
@@ -57,8 +57,30 @@ test       gateway-2  bar-com-internal-gateway-class             443    Unknown 
 			inputArgs: []string{"gateways"},
 			namespace: "default",
 			wantOut: `
+NAME       CLASS                           ADDRESSES  PORTS  PROGRAMMED  AGE
+gateway-3  foo-com-external-gateway-class             80     Unknown     <unknown>
+`,
+		},
+		{
+			name:      "get gateways -A",
+			inputArgs: []string{"gateways", "-A"},
+			namespace: "", // All namespaces
+			wantOut: `
 NAMESPACE  NAME       CLASS                           ADDRESSES  PORTS  PROGRAMMED  AGE
 default    gateway-3  foo-com-external-gateway-class             80     Unknown     <unknown>
+test       gateway-1  foo-com-external-gateway-class             80     Unknown     <unknown>
+test       gateway-2  bar-com-internal-gateway-class             443    Unknown     <unknown>
+`,
+		},
+		{
+			name:      "get gateways --all-namespaces",
+			inputArgs: []string{"gateways", "--all-namespaces"},
+			namespace: "", // All namespaces
+			wantOut: `
+NAMESPACE  NAME       CLASS                           ADDRESSES  PORTS  PROGRAMMED  AGE
+default    gateway-3  foo-com-external-gateway-class             80     Unknown     <unknown>
+test       gateway-1  foo-com-external-gateway-class             80     Unknown     <unknown>
+test       gateway-2  bar-com-internal-gateway-class             443    Unknown     <unknown>
 `,
 		},
 		{
@@ -71,8 +93,28 @@ foo-com-external-gateway-class  foo.com/external-gateway-class  Unknown   <unkno
 `,
 		},
 		{
-			name:      "get httproutes -A",
+			name:      "get httproutes",
 			inputArgs: []string{"httproutes"},
+			namespace: "default",
+			wantOut: `
+NAME         HOSTNAMES     PARENT REFS  ACCEPTED  RESOLVED  AGE
+httproute-3  example4.com  1            Unknown   Unknown   <unknown>
+`,
+		},
+		{
+			name:      "get httproutes -A",
+			inputArgs: []string{"httproutes", "-A"},
+			namespace: "", // All namespaces
+			wantOut: `
+NAMESPACE  NAME         HOSTNAMES                          PARENT REFS  ACCEPTED  RESOLVED  AGE
+default    httproute-3  example4.com                       1            Unknown   Unknown   <unknown>
+test       httproute-1  demo.com                           1            Unknown   Unknown   <unknown>
+test       httproute-2  example.com,example2.com + 1 more  2            Unknown   Unknown   <unknown>
+`,
+		},
+		{
+			name:      "get httproutes --all-namespaces",
+			inputArgs: []string{"httproutes", "--all-namespaces"},
 			namespace: "", // All namespaces
 			wantOut: `
 NAMESPACE  NAME         HOSTNAMES                          PARENT REFS  ACCEPTED  RESOLVED  AGE
@@ -86,8 +128,8 @@ test       httproute-2  example.com,example2.com + 1 more  2            Unknown 
 			inputArgs: []string{"services"},
 			namespace: "default",
 			wantOut: `
-NAMESPACE  NAME   TYPE     AGE
-default    svc-3  Service  <unknown>
+NAME   TYPE     AGE
+svc-3  Service  <unknown>
 `,
 		},
 		{
@@ -95,13 +137,23 @@ default    svc-3  Service  <unknown>
 			inputArgs: []string{"policies"},
 			namespace: "test",
 			wantOut: `
-NAMESPACE  NAME      KIND                                        TARGET(S)                               POLICY TYPE  ACCEPTED  AGE
-test       policy-1  BackendTLSPolicy.gateway.networking.k8s.io  Service/test/svc-1, Service/test/svc-2  Direct       True      <unknown>
+NAME      KIND                                        TARGET(S)                               POLICY TYPE  ACCEPTED  AGE
+policy-1  BackendTLSPolicy.gateway.networking.k8s.io  Service/test/svc-1, Service/test/svc-2  Direct       True      <unknown>
 `,
 		},
 		{
 			name:      "get policies -A",
 			inputArgs: []string{"policies", "-A"},
+			namespace: "", // All namespaces
+			wantOut: `
+NAMESPACE  NAME      KIND                                        TARGET(S)                               POLICY TYPE  ACCEPTED  AGE
+default    policy-2  BackendTLSPolicy.gateway.networking.k8s.io  Service/default/svc-3                   Direct       Partial   <unknown>
+test       policy-1  BackendTLSPolicy.gateway.networking.k8s.io  Service/test/svc-1, Service/test/svc-2  Direct       True      <unknown>
+`,
+		},
+		{
+			name:      "get policies --all-namespaces",
+			inputArgs: []string{"policies", "--all-namespaces"},
 			namespace: "", // All namespaces
 			wantOut: `
 NAMESPACE  NAME      KIND                                        TARGET(S)                               POLICY TYPE  ACCEPTED  AGE
@@ -262,8 +314,8 @@ spec:
 			inputArgs: []string{"gateways", "-o", "wide"},
 			namespace: "default",
 			wantOut: `
-NAMESPACE  NAME       CLASS                           ADDRESSES  PORTS  PROGRAMMED  AGE        POLICIES  HTTPROUTES
-default    gateway-3  foo-com-external-gateway-class             80     Unknown     <unknown>  0         1
+NAME       CLASS                           ADDRESSES  PORTS  PROGRAMMED  AGE        POLICIES  HTTPROUTES
+gateway-3  foo-com-external-gateway-class             80     Unknown     <unknown>  0         1
 `,
 		},
 	}


### PR DESCRIPTION
This PR omits the `NAMESPACE` column from `gwctl get` output when a single namespace is explicitly targeted, improving readability by removing redundant information.

Fixes #90