### PR TITLE
Fix DOT graph layout to render GatewayClass at top of hierarchy

### DIFF
--- a/pkg/topology/gateway/graphviz.go
+++ b/pkg/topology/gateway/graphviz.go
@@ -27,7 +27,7 @@ import (
 //     nodes in a single subgraph so they get rendered closer together.
 func ToDot(gwctlGraph *topology.Graph) (string, error) {
 	dotGraph := dot.NewGraph(dot.Directed)
-	dotGraph.Attr("rankdir", "BT") 
+	dotGraph.Attr("rankdir", "BT")
 
 	// Create nodes.
 	dotNodeMap := map[common.GKNN]dot.Node{}


### PR DESCRIPTION
Previously GatewayClass was rendered at the bottom of the DOT layout: 
<img width="950" height="424" alt="image" src="https://github.com/user-attachments/assets/a3594f3f-a368-4689-9f80-4d295f704a23" />

Added rankdir="BT" (bottom to top) attribute to the DOT graph output. This flips the layout direction so that GatewayClass appears at the top, correctly reflecting the Gateway API resource hierarchy. Corrected example:

<img width="589" height="270" alt="image" src="https://github.com/user-attachments/assets/93af7040-9721-41c5-b883-3c5ecbf8b085" />
