### PR TITLE
Use DOT subgraph clusters to represent namespaces

### DIFF
--- a/pkg/topology/gateway/graphviz.go
+++ b/pkg/topology/gateway/graphviz.go
@@ -18,7 +18,6 @@ package gateway
 
 import (
 	"github.com/emicklei/dot"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/gwctl/pkg/common"
 	"sigs.k8s.io/gwctl/pkg/topology"
 )
@@ -73,7 +72,7 @@ func ToDot(gwctlGraph *topology.Graph) (string, error) {
 
 			dotNode := targetGraph.Node(node.GKNN().String()).
 				Attr("style", "filled").
-				Attr("color", mapColor(node.GKNN().GroupKind()))
+				Attr("color", mapNodeColor(node))
 
 			dotNodeMap[node.GKNN()] = dotNode
 
@@ -122,10 +121,8 @@ func ToDot(gwctlGraph *topology.Graph) (string, error) {
 	return dotGraph.String(), nil
 }
 
-func mapColor(gk schema.GroupKind) string {
-	switch gk {
-	case common.NamespaceGK:
-		return "#d08770"
+func mapNodeColor(node *topology.Node) string {
+	switch node.GKNN().GroupKind() {
 	case common.GatewayClassGK:
 		return "#e5e9f0"
 	case common.GatewayGK:


### PR DESCRIPTION
This PR improves the visual representation of namespaces in the generated DOT graph by using clusters instead of regular nodes with dotted edges.

Namespaced resources are now added to their respective namespace cluster subgraph, while cluster-scoped resources (like GatewayClass) remain in the root graph. Also changed function signature from `mapNodeColor(node *topology.Node)` to `mapColor(gk common.GroupKind)` so it can be reused for both node colors and cluster colors.

Before:
<img width="568" height="266" alt="image" src="https://github.com/user-attachments/assets/7b7c1404-ba9d-43f6-b5db-df698a305ee5" />

After:
<img width="592" height="307" alt="image" src="https://github.com/user-attachments/assets/d7547061-b9f0-40cd-a6c4-2773b9298313" />
