### PR TITLE
chore: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--  Thanks for sending a pull request! Here are some tips for you:
+
+1. If this is your first time contributing to a Kubernetes project, please read
+   our contributor guidelines:
+   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
+2. Please label this pull request according to what type of issue you are
+   addressing, especially if this is a release targeted pull request. For
+   reference on required PR/issue labels, read here:
+   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
+3. If you want *faster* PR reviews, read how:
+   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
+4. If the PR is unfinished, see how to mark it:
+   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
+
+-->
+
+**What type of PR is this?**
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind feature
+/kind test
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+<!--
+*Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+-->
+Fixes #


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is mostly a copy of the [Gateway API PR template](https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/refs/heads/main/.github/PULL_REQUEST_TEMPLATE.md) with some of the less relevant bits removed.

**Which issue(s) this PR fixes**:
N/A