### PR TITLE
chore: add AI usage disclosure section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,3 +31,23 @@ Add one of the following kinds:
 Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
 -->
 Fixes #
+
+**Generative AI Usage Disclosure**
+<!--
+Using AI tools to help write your PR is acceptable, but as the author, you are responsible for understanding every change. 
+Do not leave the first review of AI generated changes to the reviewers, verify the changes (code review, testing, etc.) before submitting your PR.
+
+For more details please review guidelines on responsible Generative AI usage:
+* https://www.linuxfoundation.org/legal/generative-ai
+* https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance
+
+If you used AI tools in preparing this PR, please disclose which tools and how they were used.
+-->
+- [ ] No AI tools were used
+- [ ] AI tools were used (complete below)
+
+*AI Tools used:*
+<!-- ChatGPT, Claude, GitHub Copilot -->
+
+*How they were used:*
+<!-- Describe what the AI helped with (e.g., code generation, refactoring, documentation, tests) and which parts of the PR were affected -->


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
2. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind feature
/kind test
-->

**What this PR does / why we need it**:
With the increasing use of AI in contributions, this PR adds a Gen AI usage disclosure section to the PR template. It promotes transparency around AI-assisted work and reinforces that authors are responsible for understanding, reviewing, and validating all changes before submission.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A