### PR TITLE
fix: add guard to skip duplicate errors

### DIFF
--- a/pkg/extension/notfoundrefvalidator/notfoundrefvalidator.go
+++ b/pkg/extension/notfoundrefvalidator/notfoundrefvalidator.go
@@ -86,11 +86,9 @@ func (a *Extension) putErrorInNode(node *topology.Node, notFoundErr error) error
 		return err
 	}
 
-	for _, existingErr := range data.Errors {
-		if existingErr == notFoundErr {
-			// error is already reported
-			return nil
-		}
+	if slices.Contains(data.Errors, notFoundErr)  {
+		// error is already reported
+		return nil
 	}
 	data.Errors = append(data.Errors, notFoundErr)
 	return nil

--- a/pkg/extension/notfoundrefvalidator/notfoundrefvalidator.go
+++ b/pkg/extension/notfoundrefvalidator/notfoundrefvalidator.go
@@ -86,7 +86,7 @@ func (a *Extension) putErrorInNode(node *topology.Node, notFoundErr error) error
 		return err
 	}
 
-	if slices.Contains(data.Errors, notFoundErr)  {
+	if slices.Contains(data.Errors, notFoundErr) {
 		// error is already reported
 		return nil
 	}

--- a/pkg/extension/notfoundrefvalidator/notfoundrefvalidator.go
+++ b/pkg/extension/notfoundrefvalidator/notfoundrefvalidator.go
@@ -52,7 +52,7 @@ func (a *Extension) Execute(graph *topology.Graph) error {
 				}}
 
 				if _, ok := graph.Nodes[toNodeGKNN.GroupKind()]; !ok {
-					if err := a.puErrorInNode(fromNode, err); err != nil {
+					if err := a.putErrorInNode(fromNode, err); err != nil {
 						return err
 					}
 					klog.V(1).Info(err)
@@ -60,7 +60,7 @@ func (a *Extension) Execute(graph *topology.Graph) error {
 				}
 				toNode := graph.Nodes[toNodeGKNN.GroupKind()][toNodeGKNN.NamespacedName()]
 				if toNode == nil {
-					if err := a.puErrorInNode(fromNode, err); err != nil {
+					if err := a.putErrorInNode(fromNode, err); err != nil {
 						return err
 					}
 					klog.V(1).Info(err)
@@ -71,7 +71,7 @@ func (a *Extension) Execute(graph *topology.Graph) error {
 	return nil
 }
 
-func (a *Extension) puErrorInNode(node *topology.Node, notFoundErr error) error {
+func (a *Extension) putErrorInNode(node *topology.Node, notFoundErr error) error {
 	if node.Metadata == nil {
 		node.Metadata = map[string]any{}
 	}
@@ -84,6 +84,13 @@ func (a *Extension) puErrorInNode(node *topology.Node, notFoundErr error) error 
 	data, err := Access(node)
 	if err != nil {
 		return err
+	}
+
+	for _, existingErr := range data.Errors {
+		if existingErr == notFoundErr {
+			// error is already reported
+			return nil
+		}
 	}
 	data.Errors = append(data.Errors, notFoundErr)
 	return nil

--- a/pkg/extension/notfoundrefvalidator/notfoundrefvalidator.go
+++ b/pkg/extension/notfoundrefvalidator/notfoundrefvalidator.go
@@ -18,9 +18,9 @@ package notfoundrefvalidator
 
 import (
 	"fmt"
+	"slices"
 
 	"k8s.io/klog/v2"
-	"slices"
 
 	"sigs.k8s.io/gwctl/pkg/common"
 	"sigs.k8s.io/gwctl/pkg/topology"

--- a/pkg/extension/notfoundrefvalidator/notfoundrefvalidator.go
+++ b/pkg/extension/notfoundrefvalidator/notfoundrefvalidator.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/klog/v2"
+	"slices"
 
 	"sigs.k8s.io/gwctl/pkg/common"
 	"sigs.k8s.io/gwctl/pkg/topology"
@@ -86,11 +87,11 @@ func (a *Extension) putErrorInNode(node *topology.Node, notFoundErr error) error
 		return err
 	}
 
-	if slices.Contains(data.Errors, notFoundErr) {
-		// error is already reported
-		return nil
+	if !slices.Contains(data.Errors, notFoundErr) {
+		// new error
+		data.Errors = append(data.Errors, notFoundErr)
 	}
-	data.Errors = append(data.Errors, notFoundErr)
+
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
Renamed `puErrorInNode` to `putErrorInNode` and added a guard to prevent duplicate errors. This PR is a small bug fix.

**Which issue(s) this PR fixes**:
Fixes #116

**Generative AI Usage Disclosure**
- [X] No AI tools were used
- [ ] AI tools were used (complete below)
