### PR TITLE
feat: add GRPCRoute support

### DIFF
--- a/pkg/common/clients.go
+++ b/pkg/common/clients.go
@@ -18,10 +18,13 @@ package common //nolint:revive
 
 import (
 	"fmt"
+	"strings"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 )
 
 type GroupKindFetcher interface {
@@ -67,6 +70,13 @@ func (d defaultGroupKindFetcher) Fetch(gk schema.GroupKind) ([]*unstructured.Uns
 		Do().
 		Infos()
 	if err != nil {
+		// A resource type that the server does not know (e.g. the GRPCRoute
+		// CRD not being installed) simply means there are no such resources,
+		// so it should not fail fetches done for graph expansion.
+		if isResourceTypeNotFoundError(err) {
+			klog.V(1).InfoS("Skipping fetch since the server does not recognize the resource type", "groupKind", gk, "err", err)
+			return d.additionalResourcesByGK[gk], nil
+		}
 		return nil, err
 	}
 
@@ -83,4 +93,11 @@ func (d defaultGroupKindFetcher) Fetch(gk schema.GroupKind) ([]*unstructured.Uns
 	result = append(result, d.additionalResourcesByGK[gk]...)
 
 	return result, nil
+}
+
+func isResourceTypeNotFoundError(err error) bool {
+	// The resource builder loses the type of the underlying
+	// NoResourceMatchError in some paths, so also match on the message it
+	// produces for unknown resource types.
+	return meta.IsNoMatchError(err) || strings.Contains(err.Error(), "doesn't have a resource type")
 }

--- a/pkg/common/clients_test.go
+++ b/pkg/common/clients_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestIsResourceTypeNotFoundError(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "typed NoResourceMatchError",
+			err: &meta.NoResourceMatchError{
+				PartialResource: schema.GroupVersionResource{Resource: "grpcroutes"},
+			},
+			want: true,
+		},
+		{
+			name: "typed NoKindMatchError",
+			err: &meta.NoKindMatchError{
+				GroupKind: GRPCRouteGK,
+			},
+			want: true,
+		},
+		{
+			name: "wrapped typed error",
+			err: fmt.Errorf("fetching: %w", &meta.NoResourceMatchError{
+				PartialResource: schema.GroupVersionResource{Resource: "grpcroutes"},
+			}),
+			want: true,
+		},
+		{
+			name: "untyped resource builder message",
+			err:  errors.New(`the server doesn't have a resource type "GRPCRoute"`),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isResourceTypeNotFoundError(tc.err); got != tc.want {
+				t.Errorf("isResourceTypeNotFoundError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -36,11 +36,18 @@ var (
 	GatewayClassGK   schema.GroupKind = schema.GroupKind{Group: gatewayv1.GroupName, Kind: "GatewayClass"}
 	GatewayGK        schema.GroupKind = schema.GroupKind{Group: gatewayv1.GroupName, Kind: "Gateway"}
 	HTTPRouteGK      schema.GroupKind = schema.GroupKind{Group: gatewayv1.GroupName, Kind: "HTTPRoute"}
+	GRPCRouteGK      schema.GroupKind = schema.GroupKind{Group: gatewayv1.GroupName, Kind: "GRPCRoute"}
 	NamespaceGK      schema.GroupKind = schema.GroupKind{Group: corev1.GroupName, Kind: "Namespace"}
 	ServiceGK        schema.GroupKind = schema.GroupKind{Group: corev1.GroupName, Kind: "Service"}
 	ReferenceGrantGK schema.GroupKind = schema.GroupKind{Group: gatewayv1beta1.GroupName, Kind: "ReferenceGrant"}
 	PolicyGK         schema.GroupKind = schema.GroupKind{Group: gwctlPolicyGroup, Kind: "Policy"}
 	PolicyCRDGK      schema.GroupKind = schema.GroupKind{Group: gwctlPolicyGroup, Kind: "PolicyCRD"}
+
+	// RouteGKs lists the Route kinds that gwctl understands. Code that
+	// operates on Routes generically (topology relations, policy
+	// calculation, validation) should iterate over this list instead of
+	// assuming HTTPRoute.
+	RouteGKs = []schema.GroupKind{HTTPRouteGK, GRPCRouteGK}
 )
 
 type GKNN struct {

--- a/pkg/extension/gatewayeffectivepolicy/gatewayeffectivepolicy.go
+++ b/pkg/extension/gatewayeffectivepolicy/gatewayeffectivepolicy.go
@@ -39,7 +39,7 @@ func NewExtension() *Extension {
 	return &Extension{}
 }
 
-// Extension calculates the effective policies for all Gateways, HTTPRoutes, and
+// Extension calculates the effective policies for all Gateways, Routes, and
 // Backends in the Graph.
 func (a *Extension) Execute(graph *topology.Graph) error {
 	graph.RemoveMetadata(extensionName)
@@ -50,12 +50,12 @@ func (a *Extension) Execute(graph *topology.Graph) error {
 }
 
 // calculateInheritedPolicies calculates the inherited polices for all Gateways,
-// HTTRoutes, and Backends in the Graph.
+// Routes, and Backends in the Graph.
 func (a *Extension) calculateInheritedPolicies(graph *topology.Graph) error {
 	if err := a.calculateInheritedPoliciesForGateways(graph); err != nil {
 		return err
 	}
-	if err := a.calculateInheritedPoliciesForHTTPRoutes(graph); err != nil {
+	if err := a.calculateInheritedPoliciesForRoutes(graph); err != nil {
 		return err
 	}
 	if err := a.calculateInheritedPoliciesForBackends(graph); err != nil {
@@ -95,42 +95,44 @@ func (a *Extension) calculateInheritedPoliciesForGateways(graph *topology.Graph)
 	return nil
 }
 
-// calculateInheritedPoliciesForHTTPRoutes calculates the inherited policies for
-// all HTTPRoutes present in the Graph.
-func (a *Extension) calculateInheritedPoliciesForHTTPRoutes(graph *topology.Graph) error {
-	for _, httpRouteNode := range graph.Nodes[common.HTTPRouteGK] {
-		result := make(map[common.GKNN]*policymanager.Policy)
+// calculateInheritedPoliciesForRoutes calculates the inherited policies for
+// all Routes present in the Graph.
+func (a *Extension) calculateInheritedPoliciesForRoutes(graph *topology.Graph) error {
+	for _, routeGK := range common.RouteGKs {
+		for _, routeNode := range graph.Nodes[routeGK] {
+			result := make(map[common.GKNN]*policymanager.Policy)
 
-		// Policies inherited from HTTPRoute's namespace.
-		namespaceNode := topologygw.HTTPRouteNode(httpRouteNode).Namespace()
-		if namespaceNode != nil {
-			namespacePoliciesMap, err := directlyattachedpolicy.Access(namespaceNode)
-			if err != nil {
-				return err
+			// Policies inherited from Route's namespace.
+			namespaceNode := topologygw.RouteNode(routeNode).Namespace()
+			if namespaceNode != nil {
+				namespacePoliciesMap, err := directlyattachedpolicy.Access(namespaceNode)
+				if err != nil {
+					return err
+				}
+				maps.Copy(result, filterInheritablePolicies(namespacePoliciesMap))
 			}
-			maps.Copy(result, filterInheritablePolicies(namespacePoliciesMap))
+
+			// Policies inherited from Gateways.
+			for _, gatewayNode := range topologygw.RouteNode(routeNode).Gateways() {
+				// Add policies inherited by GatewayNode.
+				effPolicyMetadata, err := Access(gatewayNode)
+				if err != nil {
+					return err
+				}
+				if effPolicyMetadata != nil {
+					maps.Copy(result, effPolicyMetadata.GatewayInheritedPolicies)
+				}
+
+				// Add inheritable policies directly applied to GatewayNode.
+				gatewayPoliciesMap, err := directlyattachedpolicy.Access(gatewayNode)
+				if err != nil {
+					return err
+				}
+				maps.Copy(result, filterInheritablePolicies(gatewayPoliciesMap))
+			}
+
+			routeNode.Metadata[extensionName] = &NodeMetadata{RouteInheritedPolicies: result}
 		}
-
-		// Policies inherited from Gateways.
-		for _, gatewayNode := range topologygw.HTTPRouteNode(httpRouteNode).Gateways() {
-			// Add policies inherited by GatewayNode.
-			effPolicyMetadata, err := Access(gatewayNode)
-			if err != nil {
-				return err
-			}
-			if effPolicyMetadata != nil {
-				maps.Copy(result, effPolicyMetadata.GatewayInheritedPolicies)
-			}
-
-			// Add inheritable policies directly applied to GatewayNode.
-			gatewayPoliciesMap, err := directlyattachedpolicy.Access(gatewayNode)
-			if err != nil {
-				return err
-			}
-			maps.Copy(result, filterInheritablePolicies(gatewayPoliciesMap))
-		}
-
-		httpRouteNode.Metadata[extensionName] = &NodeMetadata{HTTPRouteInheritedPolicies: result}
 	}
 	return nil
 }
@@ -151,23 +153,23 @@ func (a *Extension) calculateInheritedPoliciesForBackends(graph *topology.Graph)
 			maps.Copy(result, filterInheritablePolicies(namespacePoliciesMap))
 		}
 
-		// Policies inherited from HTTPRoutes.
-		for _, httpRouteNode := range topologygw.BackendNode(backendNode).HTTPRoutes() {
-			// Add policies inherited by HTTPRouteNode.
-			effPolicyMetadata, err := Access(httpRouteNode)
+		// Policies inherited from Routes.
+		for _, routeNode := range topologygw.BackendNode(backendNode).Routes() {
+			// Add policies inherited by RouteNode.
+			effPolicyMetadata, err := Access(routeNode)
 			if err != nil {
 				return err
 			}
 			if effPolicyMetadata != nil {
-				maps.Copy(result, effPolicyMetadata.HTTPRouteInheritedPolicies)
+				maps.Copy(result, effPolicyMetadata.RouteInheritedPolicies)
 			}
 
-			// Add inheritable policies directly applied to HTTPRouteNode.
-			httpRoutePoliciesMap, err := directlyattachedpolicy.Access(httpRouteNode)
+			// Add inheritable policies directly applied to RouteNode.
+			routePoliciesMap, err := directlyattachedpolicy.Access(routeNode)
 			if err != nil {
 				return err
 			}
-			maps.Copy(result, filterInheritablePolicies(httpRoutePoliciesMap))
+			maps.Copy(result, filterInheritablePolicies(routePoliciesMap))
 		}
 
 		backendNode.Metadata[extensionName] = &NodeMetadata{BackendInheritedPolicies: result}
@@ -192,7 +194,7 @@ func (a *Extension) calculateEffectivePolicies(graph *topology.Graph) error {
 	if err := a.calculateEffectivePoliciesForGateways(graph); err != nil {
 		return err
 	}
-	if err := a.calculateEffectivePoliciesForHTTPRoutes(graph); err != nil {
+	if err := a.calculateEffectivePoliciesForRoutes(graph); err != nil {
 		return err
 	}
 	if err := a.calculateEffectivePoliciesForBackends(graph); err != nil {
@@ -284,82 +286,84 @@ func (a *Extension) calculateEffectivePoliciesForGateways(graph *topology.Graph)
 	return nil
 }
 
-// calculateEffectivePoliciesForHTTPRoutes calculates the effective policies for
-// each HTTPRoute, taking into account policies from different hierarchies
-// (GatewayClass, Namespace, Gateway, and HTTPRoute).
-func (a *Extension) calculateEffectivePoliciesForHTTPRoutes(graph *topology.Graph) error {
-	for _, httpRouteNode := range graph.Nodes[common.HTTPRouteGK] {
-		result := make(map[common.GKNN]map[policymanager.PolicyCrdID]*policymanager.Policy)
+// calculateEffectivePoliciesForRoutes calculates the effective policies for
+// each Route, taking into account policies from different hierarchies
+// (GatewayClass, Namespace, Gateway, and Route).
+func (a *Extension) calculateEffectivePoliciesForRoutes(graph *topology.Graph) error {
+	for _, routeGK := range common.RouteGKs {
+		for _, routeNode := range graph.Nodes[routeGK] {
+			result := make(map[common.GKNN]map[policymanager.PolicyCrdID]*policymanager.Policy)
 
-		namespaceNode := topologygw.HTTPRouteNode(httpRouteNode).Namespace()
-		if namespaceNode == nil {
-			klog.V(3).InfoS("No Namespace node found for HTTPRoute, skipping effective policy calculation", "httpRoute", httpRouteNode.GKNN())
-			continue
-		}
+			namespaceNode := topologygw.RouteNode(routeNode).Namespace()
+			if namespaceNode == nil {
+				klog.V(3).InfoS("No Namespace node found for Route, skipping effective policy calculation", "route", routeNode.GKNN())
+				continue
+			}
 
-		httpRoutePoliciesMap, err := directlyattachedpolicy.Access(httpRouteNode)
-		if err != nil {
-			return err
-		}
-		namespacePoliciesMap, err := directlyattachedpolicy.Access(namespaceNode)
-		if err != nil {
-			return err
-		}
-
-		// Step 1: Aggregate all policies of the HTTPRoute and the
-		// HTTPRoute-namespace.
-		httpRoutePolicies := policymanager.ConvertPoliciesMapToSlice(filterInheritablePolicies(httpRoutePoliciesMap))
-		httpRouteNamespacePolicies := policymanager.ConvertPoliciesMapToSlice(filterInheritablePolicies(namespacePoliciesMap))
-
-		// Step 2: Merge HTTPRoute and HTTPRoute-namespace policies by their kind.
-		httpRoutePoliciesByKind, err := policymanager.MergePoliciesOfSimilarKind(httpRoutePolicies)
-		if err != nil {
-			return err
-		}
-		httpRouteNamespacePoliciesByKind, err := policymanager.MergePoliciesOfSimilarKind(httpRouteNamespacePolicies)
-		if err != nil {
-			return err
-		}
-
-		// Step 3: Loop through all Gateways and merge policies for each Gateway.
-		// End result is we get policies partitioned by each Gateway.
-		for gatewayGKNN, gatewayNode := range topologygw.HTTPRouteNode(httpRouteNode).Gateways() {
-			gatewayNodeMetadata, err := Access(gatewayNode) //nolint:govet
+			routePoliciesMap, err := directlyattachedpolicy.Access(routeNode)
 			if err != nil {
 				return err
 			}
-			gatewayPoliciesByKind := gatewayNodeMetadata.GatewayEffectivePolicies
-
-			// Merge all hierarchial policies.
-			mergedPolicies, err := policymanager.MergePoliciesOfDifferentHierarchy(gatewayPoliciesByKind, httpRouteNamespacePoliciesByKind)
+			namespacePoliciesMap, err := directlyattachedpolicy.Access(namespaceNode)
 			if err != nil {
 				return err
 			}
 
-			mergedPolicies, err = policymanager.MergePoliciesOfDifferentHierarchy(mergedPolicies, httpRoutePoliciesByKind)
+			// Step 1: Aggregate all policies of the Route and the
+			// Route-namespace.
+			routePolicies := policymanager.ConvertPoliciesMapToSlice(filterInheritablePolicies(routePoliciesMap))
+			routeNamespacePolicies := policymanager.ConvertPoliciesMapToSlice(filterInheritablePolicies(namespacePoliciesMap))
+
+			// Step 2: Merge Route and Route-namespace policies by their kind.
+			routePoliciesByKind, err := policymanager.MergePoliciesOfSimilarKind(routePolicies)
+			if err != nil {
+				return err
+			}
+			routeNamespacePoliciesByKind, err := policymanager.MergePoliciesOfSimilarKind(routeNamespacePolicies)
 			if err != nil {
 				return err
 			}
 
-			result[gatewayGKNN] = mergedPolicies
-		}
+			// Step 3: Loop through all Gateways and merge policies for each Gateway.
+			// End result is we get policies partitioned by each Gateway.
+			for gatewayGKNN, gatewayNode := range topologygw.RouteNode(routeNode).Gateways() {
+				gatewayNodeMetadata, err := Access(gatewayNode) //nolint:govet
+				if err != nil {
+					return err
+				}
+				gatewayPoliciesByKind := gatewayNodeMetadata.GatewayEffectivePolicies
 
-		httpRouteNodeMetadata, err := Access(httpRouteNode)
-		if err != nil {
-			return err
+				// Merge all hierarchial policies.
+				mergedPolicies, err := policymanager.MergePoliciesOfDifferentHierarchy(gatewayPoliciesByKind, routeNamespacePoliciesByKind)
+				if err != nil {
+					return err
+				}
+
+				mergedPolicies, err = policymanager.MergePoliciesOfDifferentHierarchy(mergedPolicies, routePoliciesByKind)
+				if err != nil {
+					return err
+				}
+
+				result[gatewayGKNN] = mergedPolicies
+			}
+
+			routeNodeMetadata, err := Access(routeNode)
+			if err != nil {
+				return err
+			}
+			if routeNodeMetadata == nil {
+				routeNodeMetadata = &NodeMetadata{}
+				routeNode.Metadata[extensionName] = routeNodeMetadata
+			}
+			routeNodeMetadata.RouteEffectivePolicies = result
 		}
-		if httpRouteNodeMetadata == nil {
-			httpRouteNodeMetadata = &NodeMetadata{}
-			httpRouteNode.Metadata[extensionName] = httpRouteNodeMetadata
-		}
-		httpRouteNodeMetadata.HTTPRouteEffectivePolicies = result
 	}
 	return nil
 }
 
 // calculateEffectivePoliciesForBackends calculates the effective policies for
 // each Backend, considering policies from different hierarchies (GatewayClass,
-// Namespace, Gateway, HTTPRoute, and Backend).
+// Namespace, Gateway, Route, and Backend).
 func (a *Extension) calculateEffectivePoliciesForBackends(graph *topology.Graph) error {
 	for _, backendNode := range graph.Nodes[common.ServiceGK] {
 		result := make(map[common.GKNN]map[policymanager.PolicyCrdID]*policymanager.Policy)
@@ -393,20 +397,20 @@ func (a *Extension) calculateEffectivePoliciesForBackends(graph *topology.Graph)
 			return err
 		}
 
-		// Step 3: Loop through all HTTPRoutes and get their effective policies. Merge
+		// Step 3: Loop through all Routes and get their effective policies. Merge
 		// effective policies such that we get policies partitioned by Gateway.
-		for _, httpRouteNode := range topologygw.BackendNode(backendNode).HTTPRoutes() {
-			httpRouteNodeMetadata, err := Access(httpRouteNode) //nolint:govet
+		for _, routeNode := range topologygw.BackendNode(backendNode).Routes() {
+			routeNodeMetadata, err := Access(routeNode) //nolint:govet
 			if err != nil {
 				return err
 			}
-			if httpRouteNodeMetadata == nil {
-				klog.V(3).InfoS("No effective policy metadata found for HTTPRoute, skipping", "httpRoute", httpRouteNode.GKNN())
+			if routeNodeMetadata == nil {
+				klog.V(3).InfoS("No effective policy metadata found for Route, skipping", "route", routeNode.GKNN())
 				continue
 			}
-			httpRoutePoliciesByGateway := httpRouteNodeMetadata.HTTPRouteEffectivePolicies
+			routePoliciesByGateway := routeNodeMetadata.RouteEffectivePolicies
 
-			for gatewayID, policies := range httpRoutePoliciesByGateway {
+			for gatewayID, policies := range routePoliciesByGateway {
 				result[gatewayID], err = policymanager.MergePoliciesOfSameHierarchy(result[gatewayID], policies)
 				if err != nil {
 					return err
@@ -447,13 +451,13 @@ func (a *Extension) calculateEffectivePoliciesForBackends(graph *topology.Graph)
 }
 
 type NodeMetadata struct {
-	GatewayInheritedPolicies   map[common.GKNN]*policymanager.Policy
-	HTTPRouteInheritedPolicies map[common.GKNN]*policymanager.Policy
-	BackendInheritedPolicies   map[common.GKNN]*policymanager.Policy
+	GatewayInheritedPolicies map[common.GKNN]*policymanager.Policy
+	RouteInheritedPolicies   map[common.GKNN]*policymanager.Policy
+	BackendInheritedPolicies map[common.GKNN]*policymanager.Policy
 
-	GatewayEffectivePolicies   map[policymanager.PolicyCrdID]*policymanager.Policy
-	HTTPRouteEffectivePolicies map[common.GKNN]map[policymanager.PolicyCrdID]*policymanager.Policy
-	BackendEffectivePolicies   map[common.GKNN]map[policymanager.PolicyCrdID]*policymanager.Policy
+	GatewayEffectivePolicies map[policymanager.PolicyCrdID]*policymanager.Policy
+	RouteEffectivePolicies   map[common.GKNN]map[policymanager.PolicyCrdID]*policymanager.Policy
+	BackendEffectivePolicies map[common.GKNN]map[policymanager.PolicyCrdID]*policymanager.Policy
 }
 
 func Access(node *topology.Node) (*NodeMetadata, error) {

--- a/pkg/extension/refgrantvalidator/refgrantvalidator.go
+++ b/pkg/extension/refgrantvalidator/refgrantvalidator.go
@@ -43,14 +43,14 @@ func NewExtension(fetcher referenceGrantFetcher) *Extension {
 	return &Extension{fetcher: fetcher}
 }
 
-// Extension calculates the effective policies for all Gateways, HTTPRoutes, and
+// Extension calculates the effective policies for all Gateways, Routes, and
 // Backends in the Graph.
 func (a *Extension) Execute(graph *topology.Graph) error {
 	graph.RemoveMetadata(extensionName)
 	if err := a.discoverReferenceGrantsForBackends(graph); err != nil {
 		return err
 	}
-	return a.validateHTTPRoutes(graph)
+	return a.validateRoutes(graph)
 }
 
 func (a *Extension) discoverReferenceGrantsForBackends(graph *topology.Graph) error {
@@ -84,43 +84,45 @@ func (a *Extension) discoverReferenceGrantsForBackends(graph *topology.Graph) er
 	return nil
 }
 
-func (a *Extension) validateHTTPRoutes(graph *topology.Graph) error {
-	for _, httpRouteNode := range graph.Nodes[common.HTTPRouteGK] {
-		if httpRouteNode.Depth > graph.MaxDepth {
-			klog.V(3).InfoS("Not validating HTTPRoute since it's depth is greater than the max depth",
-				"extension", extensionName, "httpRouteNode.Depth", httpRouteNode.Depth, "MaxDepth", graph.MaxDepth,
-			)
-			continue
-		}
+func (a *Extension) validateRoutes(graph *topology.Graph) error {
+	for _, routeGK := range common.RouteGKs {
+		for _, routeNode := range graph.Nodes[routeGK] {
+			if routeNode.Depth > graph.MaxDepth {
+				klog.V(3).InfoS("Not validating Route since it's depth is greater than the max depth",
+					"extension", extensionName, "routeNode.Depth", routeNode.Depth, "MaxDepth", graph.MaxDepth,
+				)
+				continue
+			}
 
-		for backendGKNN, backendNode := range topologygw.HTTPRouteNode(httpRouteNode).Backends() {
-			// Ensure that if this is a cross namespace reference, then it is accepted
-			// through some ReferenceGrant.
-			if httpRouteNode.GKNN().Namespace != backendGKNN.Namespace {
-				backendNodeMetadata, err := Access(backendNode)
-				if err != nil {
-					return err
-				}
-
-				var referenceAccepted bool
-				if backendNodeMetadata != nil {
-					for _, referenceGrant := range backendNodeMetadata.ReferenceGrants {
-						if ReferenceGrantAccepts(referenceGrant, httpRouteNode.GKNN()) {
-							referenceAccepted = true
-							break
-						}
-					}
-				}
-				if !referenceAccepted {
-					err := common.ReferenceNotPermittedError{ReferenceFromTo: common.ReferenceFromTo{
-						ReferringObject: httpRouteNode.GKNN(),
-						ReferredObject:  backendGKNN,
-					}}
-					if err := a.putReferenceGrantErrorInNode(httpRouteNode, err); err != nil {
+			for backendGKNN, backendNode := range topologygw.RouteNode(routeNode).Backends() {
+				// Ensure that if this is a cross namespace reference, then it is accepted
+				// through some ReferenceGrant.
+				if routeNode.GKNN().Namespace != backendGKNN.Namespace {
+					backendNodeMetadata, err := Access(backendNode)
+					if err != nil {
 						return err
 					}
-					klog.V(1).InfoS("Reference not permitted", "from", httpRouteNode.GKNN(), "to", backendGKNN)
-					continue
+
+					var referenceAccepted bool
+					if backendNodeMetadata != nil {
+						for _, referenceGrant := range backendNodeMetadata.ReferenceGrants {
+							if ReferenceGrantAccepts(referenceGrant, routeNode.GKNN()) {
+								referenceAccepted = true
+								break
+							}
+						}
+					}
+					if !referenceAccepted {
+						err := common.ReferenceNotPermittedError{ReferenceFromTo: common.ReferenceFromTo{
+							ReferringObject: routeNode.GKNN(),
+							ReferredObject:  backendGKNN,
+						}}
+						if err := a.putReferenceGrantErrorInNode(routeNode, err); err != nil {
+							return err
+						}
+						klog.V(1).InfoS("Reference not permitted", "from", routeNode.GKNN(), "to", backendGKNN)
+						continue
+					}
 				}
 			}
 		}

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -65,10 +65,13 @@ func (f *ForFlag) ToOption() (common.GKNN, error) {
 		case "httproute", "httproutes":
 			objRef.Group = gatewayv1.GroupVersion.Group
 			objRef.Kind = "HTTPRoute"
+		case "grpcroute", "grpcroutes":
+			objRef.Group = gatewayv1.GroupVersion.Group
+			objRef.Kind = "GRPCRoute"
 		case "service", "services":
 			objRef.Kind = "Service"
 		default:
-			fmt.Fprintf(os.Stderr, "invalid type provided in --for flag; type must be one of [gatewayclass, gateway, httproute, service]\n")
+			fmt.Fprintf(os.Stderr, "invalid type provided in --for flag; type must be one of [gatewayclass, gateway, httproute, grpcroute, service]\n")
 			os.Exit(1)
 		}
 	}

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -65,13 +65,10 @@ func (f *ForFlag) ToOption() (common.GKNN, error) {
 		case "httproute", "httproutes":
 			objRef.Group = gatewayv1.GroupVersion.Group
 			objRef.Kind = "HTTPRoute"
-		case "grpcroute", "grpcroutes":
-			objRef.Group = gatewayv1.GroupVersion.Group
-			objRef.Kind = "GRPCRoute"
 		case "service", "services":
 			objRef.Kind = "Service"
 		default:
-			fmt.Fprintf(os.Stderr, "invalid type provided in --for flag; type must be one of [gatewayclass, gateway, httproute, grpcroute, service]\n")
+			fmt.Fprintf(os.Stderr, "invalid type provided in --for flag; type must be one of [gatewayclass, gateway, httproute, service]\n")
 			os.Exit(1)
 		}
 	}

--- a/pkg/printer/backends.go
+++ b/pkg/printer/backends.go
@@ -61,17 +61,17 @@ func (p *TablePrinter) printBackend(backendNode *topology.Node, w io.Writer) err
 
 	row := append(rowPrefixNamespaced(backend, p.AllNamespaces), backendType, age)
 	if p.OutputFormat == OutputFormatWide {
-		httpRouteNodes := maps.Values(topologygw.BackendNode(backendNode).HTTPRoutes())
-		sortedHTTPRouteNodes := topology.SortedNodes(httpRouteNodes)
-		totalRoutes := len(sortedHTTPRouteNodes)
+		routeNodes := maps.Values(topologygw.BackendNode(backendNode).Routes())
+		sortedRouteNodes := topology.SortedNodes(routeNodes)
+		totalRoutes := len(sortedRouteNodes)
 		var referredByRoutes string
 		if totalRoutes == 0 {
 			referredByRoutes = "None"
 		} else {
 			var routes []string
-			for i, httpRouteNode := range sortedHTTPRouteNodes {
+			for i, routeNode := range sortedRouteNodes {
 				if i < 2 {
-					namespacedName := httpRouteNode.GKNN().NamespacedName().String()
+					namespacedName := routeNode.GKNN().NamespacedName().String()
 					routes = append(routes, namespacedName)
 				} else {
 					break
@@ -117,10 +117,11 @@ func (p *DescriptionPrinter) printBackend(backendNode *topology.Node, w io.Write
 		ColumnNames:  []string{"Kind", "Name"},
 		UseSeparator: true,
 	}
-	for _, httpRouteNode := range topologygw.BackendNode(backendNode).HTTPRoutes() {
+	referencingRouteNodes := maps.Values(topologygw.BackendNode(backendNode).Routes())
+	for _, routeNode := range topology.SortedNodes(referencingRouteNodes) {
 		row := []string{
-			httpRouteNode.GKNN().Kind,                      // Kind
-			httpRouteNode.GKNN().NamespacedName().String(), // Name
+			routeNode.GKNN().Kind,                      // Kind
+			routeNode.GKNN().NamespacedName().String(), // Name
 		}
 		routes.Rows = append(routes.Rows, row)
 	}

--- a/pkg/printer/gateways.go
+++ b/pkg/printer/gateways.go
@@ -43,7 +43,7 @@ func (p *TablePrinter) printGateway(gatewayNode *topology.Node, w io.Writer) err
 		columnNames := namespacedBaseColumnNames(p.AllNamespaces)
 		columnNames = append(columnNames, "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE")
 		if p.OutputFormat == OutputFormatWide {
-			columnNames = append(columnNames, "POLICIES", "HTTPROUTES")
+			columnNames = append(columnNames, "POLICIES", "ROUTES")
 		}
 		p.table = &Table{
 			ColumnNames:  columnNames,
@@ -90,9 +90,9 @@ func (p *TablePrinter) printGateway(gatewayNode *topology.Node, w io.Writer) err
 		}
 		policiesCount := fmt.Sprintf("%d", len(policiesMap))
 
-		httpRoutesCount := fmt.Sprintf("%d", len(topologygw.GatewayNode(gatewayNode).HTTPRoutes()))
+		routesCount := fmt.Sprintf("%d", len(topologygw.GatewayNode(gatewayNode).Routes()))
 
-		row = append(row, policiesCount, httpRoutesCount)
+		row = append(row, policiesCount, routesCount)
 	}
 	p.table.Rows = append(p.table.Rows, row)
 
@@ -127,8 +127,8 @@ func (p *DescriptionPrinter) printGateway(gatewayNode *topology.Node, w io.Write
 	}
 
 	const (
-		maxHTTPRoutes = 10
-		maxBackends   = 10
+		maxRoutes   = 10
+		maxBackends = 10
 	)
 
 	// AttachedRoutes
@@ -141,21 +141,21 @@ func (p *DescriptionPrinter) printGateway(gatewayNode *topology.Node, w io.Write
 		ColumnNames:  []string{"Kind", "Name"},
 		UseSeparator: true,
 	}
-	httpRouteCount, backendsCount := 0, 0
-	httpRouteNodes := maps.Values(topologygw.GatewayNode(gatewayNode).HTTPRoutes())
-	for _, httpRouteNode := range topology.SortedNodes(httpRouteNodes) {
-		httpRouteCount++
-		if httpRouteCount > maxHTTPRoutes {
+	routeCount, backendsCount := 0, 0
+	routeNodes := maps.Values(topologygw.GatewayNode(gatewayNode).Routes())
+	for _, routeNode := range topology.SortedNodes(routeNodes) {
+		routeCount++
+		if routeCount > maxRoutes {
 			attachedRoutes.Rows = append(attachedRoutes.Rows, []string{"(Truncated)"})
 			break
 		}
 		row := []string{
-			httpRouteNode.GKNN().Kind,                      // Kind
-			httpRouteNode.GKNN().NamespacedName().String(), // Name
+			routeNode.GKNN().Kind,                      // Kind
+			routeNode.GKNN().NamespacedName().String(), // Name
 		}
 		attachedRoutes.Rows = append(attachedRoutes.Rows, row)
 
-		backendNodes := maps.Values(topologygw.HTTPRouteNode(httpRouteNode).Backends())
+		backendNodes := maps.Values(topologygw.RouteNode(routeNode).Backends())
 		for _, backendNode := range topology.SortedNodes(backendNodes) {
 			backendsCount++
 			if backendsCount > maxBackends {

--- a/pkg/printer/grpcroutes.go
+++ b/pkg/printer/grpcroutes.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,8 +32,8 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func (p *TablePrinter) printHTTPRoute(httpRouteNode *topology.Node, w io.Writer) error {
-	if err := p.checkTypeChange("HTTPRoute", w); err != nil {
+func (p *TablePrinter) printGRPCRoute(grpcRouteNode *topology.Node, w io.Writer) error {
+	if err := p.checkTypeChange("GRPCRoute", w); err != nil {
 		return err
 	}
 
@@ -49,10 +49,10 @@ func (p *TablePrinter) printHTTPRoute(httpRouteNode *topology.Node, w io.Writer)
 		}
 	}
 
-	httpRoute := topology.MustAccessObject(httpRouteNode, &gatewayv1.HTTPRoute{})
+	grpcRoute := topology.MustAccessObject(grpcRouteNode, &gatewayv1.GRPCRoute{})
 
 	var hostNames []string
-	for _, hostName := range httpRoute.Spec.Hostnames {
+	for _, hostName := range grpcRoute.Spec.Hostnames {
 		hostNames = append(hostNames, string(hostName))
 	}
 	hostNamesOutput := "None"
@@ -64,19 +64,19 @@ func (p *TablePrinter) printHTTPRoute(httpRouteNode *topology.Node, w io.Writer)
 		}
 	}
 
-	parentRefsCount := fmt.Sprintf("%d", len(httpRoute.Spec.ParentRefs))
+	parentRefsCount := fmt.Sprintf("%d", len(grpcRoute.Spec.ParentRefs))
 
-	acceptedStatus, resolvedStatus := routeAcceptedAndResolvedStatus(httpRoute.Status.Parents)
+	acceptedStatus, resolvedStatus := routeAcceptedAndResolvedStatus(grpcRoute.Status.Parents)
 
 	age := "<unknown>"
-	creationTimestamp := httpRoute.GetCreationTimestamp()
+	creationTimestamp := grpcRoute.GetCreationTimestamp()
 	if !creationTimestamp.IsZero() {
 		age = duration.HumanDuration(p.Clock.Since(creationTimestamp.Time))
 	}
 
-	row := append(rowPrefixNamespaced(httpRoute, p.AllNamespaces), hostNamesOutput, parentRefsCount, acceptedStatus, resolvedStatus, age)
+	row := append(rowPrefixNamespaced(grpcRoute, p.AllNamespaces), hostNamesOutput, parentRefsCount, acceptedStatus, resolvedStatus, age)
 	if p.OutputFormat == OutputFormatWide {
-		policiesMap, err := directlyattachedpolicy.Access(httpRouteNode)
+		policiesMap, err := directlyattachedpolicy.Access(grpcRouteNode)
 		if err != nil {
 			return err
 		}
@@ -87,15 +87,15 @@ func (p *TablePrinter) printHTTPRoute(httpRouteNode *topology.Node, w io.Writer)
 	return nil
 }
 
-func (p *DescriptionPrinter) printHTTPRoute(httpRouteNode *topology.Node, w io.Writer) error {
+func (p *DescriptionPrinter) printGRPCRoute(grpcRouteNode *topology.Node, w io.Writer) error {
 	if p.printSeparator {
 		fmt.Fprintf(w, "\n\n")
 	}
 	p.printSeparator = true
 
-	httpRoute := topology.MustAccessObject(httpRouteNode, &gatewayv1.HTTPRoute{})
+	grpcRoute := topology.MustAccessObject(grpcRouteNode, &gatewayv1.GRPCRoute{})
 
-	metadata := httpRoute.ObjectMeta.DeepCopy()
+	metadata := grpcRoute.ObjectMeta.DeepCopy()
 	metadata.Labels = nil
 	metadata.Annotations = nil
 	metadata.Name = ""
@@ -103,19 +103,19 @@ func (p *DescriptionPrinter) printHTTPRoute(httpRouteNode *topology.Node, w io.W
 	metadata.ManagedFields = nil
 
 	pairs := []*DescriberKV{
-		{"Name", httpRoute.GetName()},
-		{"Namespace", httpRoute.Namespace},
-		{"Label", httpRoute.Labels},
-		{"Annotations", httpRoute.Annotations},
-		{"APIVersion", httpRoute.APIVersion},
-		{"Kind", httpRoute.Kind},
+		{"Name", grpcRoute.GetName()},
+		{"Namespace", grpcRoute.Namespace},
+		{"Label", grpcRoute.Labels},
+		{"Annotations", grpcRoute.Annotations},
+		{"APIVersion", grpcRoute.APIVersion},
+		{"Kind", grpcRoute.Kind},
 		{"Metadata", metadata},
-		{"Spec", httpRoute.Spec},
-		{"Status", httpRoute.Status},
+		{"Spec", grpcRoute.Spec},
+		{"Status", grpcRoute.Status},
 	}
 
 	// DirectlyAttachedPolicies
-	policiesMap, err := directlyattachedpolicy.Access(httpRouteNode)
+	policiesMap, err := directlyattachedpolicy.Access(grpcRouteNode)
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (p *DescriptionPrinter) printHTTPRoute(httpRouteNode *topology.Node, w io.W
 	pairs = append(pairs, &DescriberKV{Key: "DirectlyAttachedPolicies", Value: convertPoliciesToRefsTable(policies, false)})
 
 	// InheritedPolicies
-	effectivePolicies, err := gatewayeffectivepolicy.Access(httpRouteNode)
+	effectivePolicies, err := gatewayeffectivepolicy.Access(grpcRouteNode)
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func (p *DescriptionPrinter) printHTTPRoute(httpRouteNode *topology.Node, w io.W
 	}
 
 	// Analysis
-	analysisErrors, err := extensionutils.AggregateAnalysisErrors(httpRouteNode)
+	analysisErrors, err := extensionutils.AggregateAnalysisErrors(grpcRouteNode)
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func (p *DescriptionPrinter) printHTTPRoute(httpRouteNode *topology.Node, w io.W
 	}
 
 	// Events
-	events, err := p.EventFetcher.FetchEventsFor(httpRoute)
+	events, err := p.EventFetcher.FetchEventsFor(grpcRoute)
 	if err != nil {
 		return err
 	}

--- a/pkg/printer/grpcroutes_test.go
+++ b/pkg/printer/grpcroutes_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printer //nolint:revive
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"sigs.k8s.io/gwctl/pkg/common"
+)
+
+func TestTablePrinter_printGRPCRoute(t *testing.T) {
+	tests := []struct {
+		name    string
+		options PrinterOptions
+		wantOut string
+	}{
+		{
+			name:    "default",
+			options: PrinterOptions{},
+			wantOut: `
+NAME          HOSTNAMES                 PARENT REFS  ACCEPTED  RESOLVED  AGE
+grpc-route-1  foo.com,bar.com + 1 more  1            True      True      <unknown>
+`,
+		},
+		{
+			name: "all namespaces",
+			options: PrinterOptions{
+				AllNamespaces: true,
+			},
+			wantOut: `
+NAMESPACE  NAME          HOSTNAMES                 PARENT REFS  ACCEPTED  RESOLVED  AGE
+ns-1       grpc-route-1  foo.com,bar.com + 1 more  1            True      True      <unknown>
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &TablePrinter{PrinterOptions: tt.options}
+			out := &bytes.Buffer{}
+
+			for _, node := range testData(t)[common.GRPCRouteGK] {
+				p.printGRPCRoute(node, out)
+				p.Flush(out)
+			}
+
+			got := common.MultiLine(out.String())
+			want := common.MultiLine(strings.TrimPrefix(tt.wantOut, "\n"))
+
+			if diff := cmp.Diff(want, got, common.MultiLineTransformer); diff != "" {
+				t.Fatalf("Unexpected diff:\n\ngot =\n\n%v\n\nwant =\n\n%v\n\ndiff (-want, +got) =\n\n%v",
+					got, want, common.MultiLine(diff))
+			}
+		})
+	}
+}

--- a/pkg/printer/main_test.go
+++ b/pkg/printer/main_test.go
@@ -164,6 +164,72 @@ func testData(t *testing.T) map[schema.GroupKind][]*topology.Node {
 		},
 	)
 
+	grpcRoute1 := mustNewNode(t,
+		&gatewayv1.GRPCRoute{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: gatewayv1.GroupVersion.String(),
+				Kind:       "GRPCRoute",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "grpc-route-1",
+				Namespace: "ns-1",
+			},
+			Spec: gatewayv1.GRPCRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"foo.com", "bar.com", "example.com"},
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Kind:      ptr.To(gatewayv1.Kind("Gateway")),
+							Group:     ptr.To(gatewayv1.Group("gateway.networking.k8s.io")),
+							Namespace: ptr.To(gatewayv1.Namespace("ns-1")),
+							Name:      "gateway-1",
+						},
+					},
+				},
+				Rules: []gatewayv1.GRPCRouteRule{
+					{
+						BackendRefs: []gatewayv1.GRPCBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Port:      ptr.To(gatewayv1.PortNumber(8080)),
+										Name:      gatewayv1.ObjectName("service-1"),
+										Kind:      ptr.To(gatewayv1.Kind("Service")),
+										Namespace: ptr.To(gatewayv1.Namespace("ns-1")),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: gatewayv1.GRPCRouteStatus{
+				RouteStatus: gatewayv1.RouteStatus{
+					Parents: []gatewayv1.RouteParentStatus{
+						{
+							ParentRef: gatewayv1.ParentReference{
+								Kind:      ptr.To(gatewayv1.Kind("Gateway")),
+								Group:     ptr.To(gatewayv1.Group("gateway.networking.k8s.io")),
+								Namespace: ptr.To(gatewayv1.Namespace("ns-1")),
+								Name:      "gateway-1",
+							},
+							Conditions: []metav1.Condition{
+								{
+									Type:   "Accepted",
+									Status: "True",
+								},
+								{
+									Type:   "ResolvedRefs",
+									Status: "True",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
 	service1 := mustNewNode(t, &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -180,6 +246,7 @@ func testData(t *testing.T) map[schema.GroupKind][]*topology.Node {
 	graph.AddNode(gatewayClass1)
 	graph.AddNode(gateway1)
 	graph.AddNode(httpRoute1)
+	graph.AddNode(grpcRoute1)
 	graph.AddNode(service1)
 
 	result := map[schema.GroupKind][]*topology.Node{}

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -136,6 +136,7 @@ type typedPrinter interface {
 	printGatewayClass(*topology.Node, io.Writer) error
 	printGateway(*topology.Node, io.Writer) error
 	printHTTPRoute(*topology.Node, io.Writer) error
+	printGRPCRoute(*topology.Node, io.Writer) error
 	printNamespace(*topology.Node, io.Writer) error
 	printPolicy(*topology.Node, io.Writer) error
 	printPolicyCRD(*topology.Node, io.Writer) error
@@ -157,6 +158,8 @@ func parseAndPrint(node *topology.Node, w io.Writer, p typedPrinter) error {
 		return p.printGatewayClass(node, w)
 	case common.HTTPRouteGK:
 		return p.printHTTPRoute(node, w)
+	case common.GRPCRouteGK:
+		return p.printGRPCRoute(node, w)
 	case common.NamespaceGK:
 		return p.printNamespace(node, w)
 	case common.ServiceGK:

--- a/pkg/printer/utils.go
+++ b/pkg/printer/utils.go
@@ -36,6 +36,8 @@ import (
 
 	"sigs.k8s.io/gwctl/pkg/common"
 	"sigs.k8s.io/gwctl/pkg/policymanager"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // DescriberKV stores key-value pairs that are used with Describing a resource.
@@ -144,6 +146,33 @@ func rowPrefixNamespaced(obj metav1.Object, allNamespaces bool) []string {
 		return []string{obj.GetNamespace(), obj.GetName()}
 	}
 	return []string{obj.GetName()}
+}
+
+// routeAcceptedAndResolvedStatus summarizes the Accepted and ResolvedRefs
+// conditions of a Route across all of its parents.
+func routeAcceptedAndResolvedStatus(parents []gatewayv1.RouteParentStatus) (acceptedStatus, resolvedStatus string) {
+	summarize := func(conditionType string) string {
+		count := 0
+		for _, parentStatus := range parents {
+			for _, condition := range parentStatus.Conditions {
+				if condition.Type == conditionType && condition.Status == "True" {
+					count++
+					break
+				}
+			}
+		}
+		switch {
+		case len(parents) == 0:
+			return "Unknown"
+		case count == len(parents):
+			return "True"
+		case count > 0:
+			return "Partial"
+		default:
+			return "False"
+		}
+	}
+	return summarize("Accepted"), summarize("ResolvedRefs")
 }
 
 func convertEventsSliceToTable(events []*corev1.Event, clock clock.Clock) *Table {

--- a/pkg/topology/gateway/gateway.go
+++ b/pkg/topology/gateway/gateway.go
@@ -18,10 +18,12 @@ package gateway
 
 import (
 	"fmt"
+	"maps"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"sigs.k8s.io/gwctl/pkg/common"
 	"sigs.k8s.io/gwctl/pkg/topology"
@@ -34,8 +36,11 @@ var (
 		GatewayParentGatewayClassRelation,
 		HTTPRouteParentGatewaysRelation,
 		HTTPRouteChildBackendRefsRelation,
+		GRPCRouteParentGatewaysRelation,
+		GRPCRouteChildBackendRefsRelation,
 		GatewayNamespace,
 		HTTPRouteNamespace,
+		GRPCRouteNamespace,
 		BackendNamespace,
 	}
 
@@ -117,40 +122,71 @@ var (
 				}
 			}
 
-			// Convert each BackendRef to GKNN. GNKK does not use pointers and
-			// thus is easily comparable.
-			resultSet := make(map[common.GKNN]bool)
-			for _, backendRef := range backendRefs {
-				objRef := common.GKNN{
-					Name: string(backendRef.Name),
-					// Assume namespace is unspecified in the backendRef and
-					// check later to override the default value.
-					Namespace: httpRoute.GetNamespace(),
-				}
-				if backendRef.Group != nil {
-					objRef.Group = string(*backendRef.Group)
-				}
-				if backendRef.Kind != nil {
-					objRef.Kind = string(*backendRef.Kind)
-				} else {
-					// Although for resources existing on the server, this value
-					// should have received a default before getting persisted.
-					// We still explicitly set this for the local analysis when
-					// the defaults do not get set automatically.
-					objRef.Kind = common.ServiceGK.Kind
-				}
-				if backendRef.Namespace != nil {
-					objRef.Namespace = string(*backendRef.Namespace)
-				}
-				resultSet[objRef] = true
-			}
+			return backendRefsToUniqueGKNNs(backendRefs, httpRoute.GetNamespace())
+		},
+	}
 
-			// Return unique objRefs
-			var result []common.GKNN
-			for objRef := range resultSet {
-				result = append(result, objRef)
+	// GRPCRouteParentGatewaysRelation returns Gateways which the GRPCRoute is
+	// attached to.
+	GRPCRouteParentGatewaysRelation = &topology.Relation{
+		From: common.GRPCRouteGK,
+		To:   common.GatewayGK,
+		Name: "ParentRef",
+		NeighborFunc: func(u *unstructured.Unstructured) []common.GKNN {
+			grpcRoute := &gatewayv1.GRPCRoute{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), grpcRoute); err != nil {
+				panic(fmt.Sprintf("failed to convert unstructured GRPCRoute to structured: %v", err))
+			}
+			result := []common.GKNN{}
+			for _, gatewayRef := range grpcRoute.Spec.ParentRefs {
+				namespace := grpcRoute.GetNamespace()
+				if namespace == "" {
+					namespace = metav1.NamespaceDefault
+				}
+				if gatewayRef.Namespace != nil {
+					namespace = string(*gatewayRef.Namespace)
+				}
+
+				result = append(result, common.GKNN{
+					Group:     common.GatewayGK.Group,
+					Kind:      common.GatewayGK.Kind,
+					Namespace: namespace,
+					Name:      string(gatewayRef.Name),
+				})
 			}
 			return result
+		},
+	}
+
+	// GRPCRouteChildBackendRefsRelation returns Backends which the GRPCRoute
+	// references.
+	GRPCRouteChildBackendRefsRelation = &topology.Relation{
+		From: common.GRPCRouteGK,
+		To:   common.ServiceGK,
+		Name: "BackendRef",
+		NeighborFunc: func(u *unstructured.Unstructured) []common.GKNN {
+			grpcRoute := &gatewayv1.GRPCRoute{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), grpcRoute); err != nil {
+				panic(fmt.Sprintf("failed to convert unstructured GRPCRoute to structured: %v", err))
+			}
+			// Aggregate all BackendRefs
+			var backendRefs []gatewayv1.BackendObjectReference
+			for _, rule := range grpcRoute.Spec.Rules {
+				for _, backendRef := range rule.BackendRefs {
+					backendRefs = append(backendRefs, backendRef.BackendObjectReference)
+				}
+				for _, filter := range rule.Filters {
+					if filter.Type != gatewayv1.GRPCRouteFilterRequestMirror {
+						continue
+					}
+					if filter.RequestMirror == nil {
+						continue
+					}
+					backendRefs = append(backendRefs, filter.RequestMirror.BackendRef)
+				}
+			}
+
+			return backendRefsToUniqueGKNNs(backendRefs, grpcRoute.GetNamespace())
 		},
 	}
 
@@ -182,6 +218,20 @@ var (
 		},
 	}
 
+	// GRPCRouteNamespace returns the Namespace for the GRPCRoute.
+	GRPCRouteNamespace = &topology.Relation{
+		From: common.GRPCRouteGK,
+		To:   common.NamespaceGK,
+		Name: "Namespace",
+		NeighborFunc: func(u *unstructured.Unstructured) []common.GKNN {
+			return []common.GKNN{{
+				Group: common.NamespaceGK.Group,
+				Kind:  common.NamespaceGK.Kind,
+				Name:  u.GetNamespace(),
+			}}
+		},
+	}
+
 	// BackendNamespace returns the Namespace for the Gateway.
 	BackendNamespace = &topology.Relation{
 		From: common.ServiceGK,
@@ -196,6 +246,62 @@ var (
 		},
 	}
 )
+
+// backendRefsToUniqueGKNNs converts BackendRefs to GKNNs and deduplicates
+// them. GKNN does not use pointers and thus is easily comparable.
+func backendRefsToUniqueGKNNs(backendRefs []gatewayv1.BackendObjectReference, routeNamespace string) []common.GKNN {
+	resultSet := make(map[common.GKNN]bool)
+	for _, backendRef := range backendRefs {
+		objRef := common.GKNN{
+			Name: string(backendRef.Name),
+			// Assume namespace is unspecified in the backendRef and
+			// check later to override the default value.
+			Namespace: routeNamespace,
+		}
+		if backendRef.Group != nil {
+			objRef.Group = string(*backendRef.Group)
+		}
+		if backendRef.Kind != nil {
+			objRef.Kind = string(*backendRef.Kind)
+		} else {
+			// Although for resources existing on the server, this value
+			// should have received a default before getting persisted.
+			// We still explicitly set this for the local analysis when
+			// the defaults do not get set automatically.
+			objRef.Kind = common.ServiceGK.Kind
+		}
+		if backendRef.Namespace != nil {
+			objRef.Namespace = string(*backendRef.Namespace)
+		}
+		resultSet[objRef] = true
+	}
+
+	// Return unique objRefs
+	var result []common.GKNN
+	for objRef := range resultSet {
+		result = append(result, objRef)
+	}
+	return result
+}
+
+// routeRelations maps each Route kind to the relations used to traverse from
+// that Route to its neighbors.
+var routeRelations = map[schema.GroupKind]struct {
+	parentGateways   *topology.Relation
+	childBackendRefs *topology.Relation
+	namespace        *topology.Relation
+}{
+	common.HTTPRouteGK: {
+		parentGateways:   HTTPRouteParentGatewaysRelation,
+		childBackendRefs: HTTPRouteChildBackendRefsRelation,
+		namespace:        HTTPRouteNamespace,
+	},
+	common.GRPCRouteGK: {
+		parentGateways:   GRPCRouteParentGatewaysRelation,
+		childBackendRefs: GRPCRouteChildBackendRefsRelation,
+		namespace:        GRPCRouteNamespace,
+	},
+}
 
 type gatewayClassNode interface {
 	Gateways() map[common.GKNN]*topology.Node
@@ -216,7 +322,7 @@ func (n *gatewayNodeClassImpl) Gateways() map[common.GKNN]*topology.Node {
 type gatewayNode interface {
 	Namespace() *topology.Node
 	GatewayClass() *topology.Node
-	HTTPRoutes() map[common.GKNN]*topology.Node
+	Routes() map[common.GKNN]*topology.Node
 }
 
 type gatewayNodeImpl struct {
@@ -241,42 +347,49 @@ func (n *gatewayNodeImpl) GatewayClass() *topology.Node {
 	return nil
 }
 
-func (n *gatewayNodeImpl) HTTPRoutes() map[common.GKNN]*topology.Node {
-	return n.node.InNeighbors[HTTPRouteParentGatewaysRelation]
+// Routes returns all Routes (of any kind) attached to the Gateway.
+func (n *gatewayNodeImpl) Routes() map[common.GKNN]*topology.Node {
+	result := make(map[common.GKNN]*topology.Node)
+	for _, relations := range routeRelations {
+		maps.Copy(result, n.node.InNeighbors[relations.parentGateways])
+	}
+	return result
 }
 
-type httpRouteNode interface {
+type routeNode interface {
 	Namespace() *topology.Node
 	Gateways() map[common.GKNN]*topology.Node
 	Backends() map[common.GKNN]*topology.Node
 }
 
-type httpRouteNodeImpl struct {
+type routeNodeImpl struct {
 	node *topology.Node
 }
 
-func HTTPRouteNode(node *topology.Node) httpRouteNode {
-	return &httpRouteNodeImpl{node: node}
+// RouteNode wraps a topology Node of any Route kind (HTTPRoute, GRPCRoute)
+// with accessors for its neighbors.
+func RouteNode(node *topology.Node) routeNode {
+	return &routeNodeImpl{node: node}
 }
 
-func (n *httpRouteNodeImpl) Namespace() *topology.Node {
-	for _, namespaceNode := range n.node.OutNeighbors[HTTPRouteNamespace] {
+func (n *routeNodeImpl) Namespace() *topology.Node {
+	for _, namespaceNode := range n.node.OutNeighbors[routeRelations[n.node.GKNN().GroupKind()].namespace] {
 		return namespaceNode
 	}
 	return nil
 }
 
-func (n *httpRouteNodeImpl) Gateways() map[common.GKNN]*topology.Node {
-	return n.node.OutNeighbors[HTTPRouteParentGatewaysRelation]
+func (n *routeNodeImpl) Gateways() map[common.GKNN]*topology.Node {
+	return n.node.OutNeighbors[routeRelations[n.node.GKNN().GroupKind()].parentGateways]
 }
 
-func (n *httpRouteNodeImpl) Backends() map[common.GKNN]*topology.Node {
-	return n.node.OutNeighbors[HTTPRouteChildBackendRefsRelation]
+func (n *routeNodeImpl) Backends() map[common.GKNN]*topology.Node {
+	return n.node.OutNeighbors[routeRelations[n.node.GKNN().GroupKind()].childBackendRefs]
 }
 
 type backendNode interface {
 	Namespace() *topology.Node
-	HTTPRoutes() map[common.GKNN]*topology.Node
+	Routes() map[common.GKNN]*topology.Node
 }
 
 type backendNodeImpl struct {
@@ -294,6 +407,11 @@ func (n *backendNodeImpl) Namespace() *topology.Node {
 	return nil
 }
 
-func (n *backendNodeImpl) HTTPRoutes() map[common.GKNN]*topology.Node {
-	return n.node.InNeighbors[HTTPRouteChildBackendRefsRelation]
+// Routes returns all Routes (of any kind) that reference the Backend.
+func (n *backendNodeImpl) Routes() map[common.GKNN]*topology.Node {
+	result := make(map[common.GKNN]*topology.Node)
+	for _, relations := range routeRelations {
+		maps.Copy(result, n.node.InNeighbors[relations.childBackendRefs])
+	}
+	return result
 }

--- a/pkg/topology/gateway/gateway.go
+++ b/pkg/topology/gateway/gateway.go
@@ -139,6 +139,17 @@ var (
 			}
 			result := []common.GKNN{}
 			for _, gatewayRef := range grpcRoute.Spec.ParentRefs {
+				// ParentRefs may target other kinds (for example a Service in
+				// mesh deployments); only emit edges for refs that actually
+				// point at a Gateway. Both Group and Kind default to the
+				// Gateway values when unset.
+				if gatewayRef.Group != nil && string(*gatewayRef.Group) != common.GatewayGK.Group {
+					continue
+				}
+				if gatewayRef.Kind != nil && string(*gatewayRef.Kind) != common.GatewayGK.Kind {
+					continue
+				}
+
 				namespace := grpcRoute.GetNamespace()
 				if namespace == "" {
 					namespace = metav1.NamespaceDefault

--- a/pkg/topology/gateway/gateway_test.go
+++ b/pkg/topology/gateway/gateway_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/gwctl/pkg/common"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// GRPCRoute ParentRefs may target kinds other than Gateway (for example a
+// Service in mesh deployments); only refs that actually point at a Gateway
+// may produce Gateway edges.
+func TestGRPCRouteParentGatewaysRelationSkipsNonGatewayParents(t *testing.T) {
+	grpcRoute := &gatewayv1.GRPCRoute{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gatewayv1.GroupVersion.String(),
+			Kind:       "GRPCRoute",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "grpc-route",
+			Namespace: "ns-1",
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					// Implicit Gateway (both Group and Kind unset).
+					{Name: "implicit-gateway"},
+					// Explicit Gateway.
+					{
+						Group: ptr.To(gatewayv1.Group(common.GatewayGK.Group)),
+						Kind:  ptr.To(gatewayv1.Kind("Gateway")),
+						Name:  "explicit-gateway",
+					},
+					// Service parent (mesh case): must not become a Gateway.
+					{
+						Group: ptr.To(gatewayv1.Group("")),
+						Kind:  ptr.To(gatewayv1.Kind("Service")),
+						Name:  "parent-svc",
+					},
+					// Non-Gateway kind in the Gateway API group.
+					{
+						Kind: ptr.To(gatewayv1.Kind("XListenerSet")),
+						Name: "listener-set",
+					},
+				},
+			},
+		},
+	}
+
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(grpcRoute)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := GRPCRouteParentGatewaysRelation.NeighborFunc(&unstructured.Unstructured{Object: obj})
+
+	want := []common.GKNN{
+		{
+			Group:     common.GatewayGK.Group,
+			Kind:      common.GatewayGK.Kind,
+			Namespace: "ns-1",
+			Name:      "implicit-gateway",
+		},
+		{
+			Group:     common.GatewayGK.Group,
+			Kind:      common.GatewayGK.Kind,
+			Namespace: "ns-1",
+			Name:      "explicit-gateway",
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected neighbors (-want, +got):\n%s", diff)
+	}
+}

--- a/pkg/topology/gateway/graphviz.go
+++ b/pkg/topology/gateway/graphviz.go
@@ -119,12 +119,12 @@ func ToDot(gwctlGraph *topology.Graph) (string, error) {
 
 				dotToNode := dotNodeMap[toNodeGKNN]
 
-				// If this is an edge from an HTTPRoute to a Service, then
+				// If this is an edge from a Route to a Service, then
 				// reverse the direction of the edge (to affect the rank), and
 				// then reverse the display again to show the correct direction.
 				// The end result being that Services now get assigned the
 				// correct rank.
-				reverse := fromNode.GKNN().GroupKind() == common.HTTPRouteGK && toNodeGKNN.GroupKind() == common.ServiceGK
+				reverse := slices.Contains(common.RouteGKs, fromNode.GKNN().GroupKind()) && toNodeGKNN.GroupKind() == common.ServiceGK
 				u, v := dotFromNode, dotToNode
 				if reverse {
 					u, v = v, u
@@ -152,7 +152,7 @@ func mapNodeColor(node *topology.Node) string {
 		return "#e5e9f0"
 	case common.GatewayGK:
 		return "#ebcb8b"
-	case common.HTTPRouteGK:
+	case common.HTTPRouteGK, common.GRPCRouteGK:
 		return "#a3be8c"
 	case common.ServiceGK:
 		return "#88c0d0"

--- a/test/integration/get_test.go
+++ b/test/integration/get_test.go
@@ -124,6 +124,37 @@ test       httproute-2  example.com,example2.com + 1 more  2            Unknown 
 `,
 		},
 		{
+			name:      "get grpcroutes -n test",
+			inputArgs: []string{"grpcroutes"},
+			namespace: "test",
+			wantOut: `
+NAME         HOSTNAMES      PARENT REFS  ACCEPTED  RESOLVED  AGE
+grpcroute-1  grpc.demo.com  1            Unknown   Unknown   <unknown>
+`,
+		},
+		{
+			name:      "get grpcroutes -A",
+			inputArgs: []string{"grpcroutes", "-A"},
+			namespace: "", // All namespaces
+			wantOut: `
+NAMESPACE  NAME         HOSTNAMES      PARENT REFS  ACCEPTED  RESOLVED  AGE
+test       grpcroute-1  grpc.demo.com  1            Unknown   Unknown   <unknown>
+`,
+		},
+		{
+			name:      "get httproutes,grpcroutes -n test",
+			inputArgs: []string{"httproutes,grpcroutes"},
+			namespace: "test",
+			wantOut: `
+NAME         HOSTNAMES      PARENT REFS  ACCEPTED  RESOLVED  AGE
+grpcroute-1  grpc.demo.com  1            Unknown   Unknown   <unknown>
+
+NAME         HOSTNAMES                          PARENT REFS  ACCEPTED  RESOLVED  AGE
+httproute-1  demo.com                           1            Unknown   Unknown   <unknown>
+httproute-2  example.com,example2.com + 1 more  2            Unknown   Unknown   <unknown>
+`,
+		},
+		{
 			name:      "get services",
 			inputArgs: []string{"services"},
 			namespace: "default",
@@ -185,11 +216,13 @@ Status: {}
 AttachedRoutes:
   Kind       Name
   ----       ----
+  GRPCRoute  test/grpcroute-1
   HTTPRoute  test/httproute-1
   HTTPRoute  test/httproute-2
 Backends:
   Kind     Name
   ----     ----
+  Service  test/svc-2
   Service  test/svc-1
   Service  test/svc-2
 DirectlyAttachedPolicies: <none>
@@ -251,11 +284,13 @@ Status: {}
 AttachedRoutes:
   Kind       Name
   ----       ----
+  GRPCRoute  test/grpcroute-1
   HTTPRoute  test/httproute-1
   HTTPRoute  test/httproute-2
 Backends:
   Kind     Name
   ----     ----
+  Service  test/svc-2
   Service  test/svc-1
   Service  test/svc-2
 DirectlyAttachedPolicies: <none>
@@ -314,7 +349,7 @@ spec:
 			inputArgs: []string{"gateways", "-o", "wide"},
 			namespace: "default",
 			wantOut: `
-NAME       CLASS                           ADDRESSES  PORTS  PROGRAMMED  AGE        POLICIES  HTTPROUTES
+NAME       CLASS                           ADDRESSES  PORTS  PROGRAMMED  AGE        POLICIES  ROUTES
 gateway-3  foo-com-external-gateway-class             80     Unknown     <unknown>  0         1
 `,
 		},

--- a/test/integration/get_test.go
+++ b/test/integration/get_test.go
@@ -142,6 +142,50 @@ test       grpcroute-1  grpc.demo.com  1            Unknown   Unknown   <unknown
 `,
 		},
 		{
+			name:      "get grpcroutes -o wide -n test",
+			inputArgs: []string{"grpcroutes", "-o", "wide"},
+			namespace: "test",
+			wantOut: `
+NAME         HOSTNAMES      PARENT REFS  ACCEPTED  RESOLVED  AGE        POLICIES
+grpcroute-1  grpc.demo.com  1            Unknown   Unknown   <unknown>  0
+`,
+		},
+		{
+			name:      "describe grpcroutes -n test",
+			inputArgs: []string{"grpcroutes"},
+			namespace: "test",
+			describe:  true,
+			wantOut: `
+Name: grpcroute-1
+Namespace: test
+Label: null
+Annotations: null
+APIVersion: gateway.networking.k8s.io/v1
+Kind: GRPCRoute
+Metadata: {}
+Spec:
+  hostnames:
+  - grpc.demo.com
+  parentRefs:
+  - kind: Gateway
+    name: gateway-1
+  rules:
+  - backendRefs:
+    - name: svc-2
+      port: 9000
+    matches:
+    - method:
+        service: com.example.EchoService
+Status:
+  parents: null
+DirectlyAttachedPolicies: <none>
+InheritedPolicies: <none>
+EffectivePolicies:
+  Gateway.gateway.networking.k8s.io/test/gateway-1: {}
+Events: <none>
+`,
+		},
+		{
 			name:      "get httproutes,grpcroutes -n test",
 			inputArgs: []string{"httproutes,grpcroutes"},
 			namespace: "test",

--- a/test/integration/missing_crd_test.go
+++ b/test/integration/missing_crd_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	cmdget "sigs.k8s.io/gwctl/cmd/get"
+	"sigs.k8s.io/gwctl/pkg/common"
+)
+
+const testdataWithoutGRPCRoutes = `
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: foo-com-external-gateway-class
+spec:
+  controllerName: foo.com/external-gateway-class
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-1
+  namespace: default
+spec:
+  gatewayClassName: foo-com-external-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-1
+  namespace: default
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: gateway-1
+  rules:
+  - backendRefs:
+    - name: svc-1
+      port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-1
+  namespace: default
+spec:
+  type: ClusterIP
+`
+
+// Regression test for graph expansion on clusters where the GRPCRoute CRD is
+// not installed: fetches done for relation expansion must skip the unknown
+// resource type instead of failing the whole command.
+func TestGetSucceedsWithoutGRPCRouteCRD(t *testing.T) {
+	factory := NewTestFactoryWithoutResources(t, []string{"grpcroutes"}, testdataWithoutGRPCRoutes)
+	factory.namespace = "default"
+
+	iostreams, _, out, errOut := genericiooptions.NewTestIOStreams()
+	// `-o wide` forces relationship expansion, which includes the GRPCRoute
+	// relations.
+	cmd := cmdget.NewCmd(factory, iostreams, false)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"gateways", "-o", "wide"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("get gateways -o wide should succeed without the GRPCRoute CRD, got: %v\nout=%v\nerrOut=%v",
+			err, out.String(), errOut.String())
+	}
+
+	wantOut := `
+NAME       CLASS                           ADDRESSES  PORTS  PROGRAMMED  AGE        POLICIES  ROUTES
+gateway-1  foo-com-external-gateway-class             80     Unknown     <unknown>  0         1
+`
+
+	got := common.MultiLine(out.String())
+	want := common.MultiLine(strings.TrimPrefix(wantOut, "\n"))
+	if diff := cmp.Diff(want, got, common.MultiLineTransformer); diff != "" {
+		t.Fatalf("Unexpected diff:\n\ngot =\n\n%v\n\nwant =\n\n%v\n\ndiff (-want, +got) =\n\n%v",
+			got, want, common.MultiLine(diff))
+	}
+}
+
+// The fetcher used for graph expansion must return no resources (not an
+// error) for a resource type the server does not recognize, while still
+// returning resources for types it does.
+func TestFetchToleratesMissingResourceType(t *testing.T) {
+	factory := NewTestFactoryWithoutResources(t, []string{"grpcroutes"}, testdataWithoutGRPCRoutes)
+	fetcher := common.NewDefaultGroupKindFetcher(factory)
+
+	grpcRoutes, err := fetcher.Fetch(common.GRPCRouteGK)
+	if err != nil {
+		t.Fatalf("fetching an unknown resource type should be tolerated, got: %v", err)
+	}
+	if len(grpcRoutes) != 0 {
+		t.Fatalf("expected no GRPCRoutes, got %d", len(grpcRoutes))
+	}
+
+	httpRoutes, err := fetcher.Fetch(common.HTTPRouteGK)
+	if err != nil {
+		t.Fatalf("fetching a known resource type should succeed, got: %v", err)
+	}
+	if len(httpRoutes) != 1 {
+		t.Fatalf("expected 1 HTTPRoute, got %d", len(httpRoutes))
+	}
+}

--- a/test/integration/testdata/graphviz/graph-single-namespace.gv
+++ b/test/integration/testdata/graphviz/graph-single-namespace.gv
@@ -1,16 +1,19 @@
 digraph  {
 	subgraph cluster_s1 {
 		color="black";label="Namespace: default";style="dashed";
-		n2[color="#ebcb8b",label="Gateway\ngateway-1",style="filled"];
-		n4[color="#a3be8c",label="HTTPRoute\nhttproute-1",style="filled"];
-		n5[color="#88c0d0",label="Service\nsvc-1",style="filled"];
+		n2[color="#a3be8c",label="GRPCRoute\ngrpcroute-1",style="filled"];
+		n3[color="#ebcb8b",label="Gateway\ngateway-1",style="filled"];
+		n5[color="#a3be8c",label="HTTPRoute\nhttproute-1",style="filled"];
+		n6[color="#88c0d0",label="Service\nsvc-1",style="filled"];
 		
 	}
 	compound="true";rankdir="BT";
-	n3[color="#e5e9f0",label="GatewayClass\nfoo-com-external-gateway-class",style="filled"];
-	n2->n3[label="GatewayClass"];
-	n4->n2[label="ParentRef"];
-	n5->n4[dir="back",label="BackendRef"];
+	n4[color="#e5e9f0",label="GatewayClass\nfoo-com-external-gateway-class",style="filled"];
+	n2->n3[label="ParentRef"];
+	n3->n4[label="GatewayClass"];
+	n5->n3[label="ParentRef"];
+	n6->n2[dir="back",label="BackendRef"];
+	n6->n5[dir="back",label="BackendRef"];
 	
 }
 

--- a/test/integration/testdata/graphviz/graph-single-namespace.yaml
+++ b/test/integration/testdata/graphviz/graph-single-namespace.yaml
@@ -56,3 +56,22 @@ spec:
     port: 80
     protocol: TCP
     targetPort: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpcroute-1
+  namespace: default
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: gateway-1
+  hostnames:
+  - "grpc.demo.com"
+  rules:
+  - matches:
+    - method:
+        service: com.example.EchoService
+    backendRefs:
+    - name: svc-1
+      port: 9000

--- a/test/integration/testdata/sample1.yaml
+++ b/test/integration/testdata/sample1.yaml
@@ -138,6 +138,28 @@ spec:
       port: 80
 ---
 ################################################################################
+# GRPCRoutes
+################################################################################
+kind: GRPCRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: grpcroute-1
+  namespace: test
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: gateway-1
+  hostnames:
+  - "grpc.demo.com"
+  rules:
+  - matches:
+    - method:
+        service: com.example.EchoService
+    backendRefs:
+    - name: svc-2
+      port: 9000
+---
+################################################################################
 # Services
 ################################################################################
 apiVersion: v1

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -53,6 +53,13 @@ type TestFactory struct {
 }
 
 func NewTestFactory(t *testing.T, yamls ...string) *TestFactory {
+	return NewTestFactoryWithoutResources(t, nil, yamls...)
+}
+
+// NewTestFactoryWithoutResources builds a TestFactory whose fake server does
+// not recognize the named resources (e.g. "grpcroutes"), imitating a cluster
+// where those CRDs are not installed.
+func NewTestFactoryWithoutResources(t *testing.T, excludedResourceNames []string, yamls ...string) *TestFactory {
 	yaml := strings.Join(yamls, "\n---\n")
 
 	infos, err := resource.NewLocalBuilder().
@@ -66,7 +73,7 @@ func NewTestFactory(t *testing.T, yamls ...string) *TestFactory {
 		t.Fatal(err)
 	}
 
-	restMapper := mustRestMapper(t, infos)
+	restMapper := mustRestMapper(t, infos, excludedResourceNames)
 
 	f := &TestFactory{
 		unstructuredClient: mustFakeRestClient(t, infos, restMapper),
@@ -93,8 +100,9 @@ func (f *TestFactory) KubeConfigNamespace() (string, bool, error) {
 	return f.namespace, false, nil
 }
 
-// mustRestMapper maintains a set of all resources recognized by the fake server.
-func mustRestMapper(t *testing.T, infos []*resource.Info) meta.RESTMapper {
+// mustRestMapper maintains a set of all resources recognized by the fake
+// server, minus any resources named in excludedResourceNames.
+func mustRestMapper(t *testing.T, infos []*resource.Info, excludedResourceNames []string) meta.RESTMapper {
 	resourceList := []*metav1.APIResourceList{
 		{
 			GroupVersion: gatewayv1.GroupVersion.String(),
@@ -167,6 +175,12 @@ func mustRestMapper(t *testing.T, infos []*resource.Info) meta.RESTMapper {
 				APIResources: apiResources,
 			})
 		}
+	}
+
+	for _, list := range resourceList {
+		list.APIResources = slices.DeleteFunc(list.APIResources, func(apiResource metav1.APIResource) bool {
+			return slices.Contains(excludedResourceNames, apiResource.Name)
+		})
 	}
 
 	fakeDiscoveryClient := &fakediscovery.FakeDiscovery{

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -102,6 +102,7 @@ func mustRestMapper(t *testing.T, infos []*resource.Info) meta.RESTMapper {
 				{Name: "gatewayclasses", Namespaced: false, Kind: common.GatewayClassGK.Kind},
 				{Name: "gateways", Namespaced: true, Kind: common.GatewayGK.Kind},
 				{Name: "httproutes", Namespaced: true, Kind: common.HTTPRouteGK.Kind},
+				{Name: "grpcroutes", Namespaced: true, Kind: common.GRPCRouteGK.Kind},
 				{Name: "referencegrants", Namespaced: true, Kind: common.ReferenceGrantGK.Kind},
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds GRPCRoute support to gwctl, following the same behavior HTTPRoute already has:

- `gwctl get grpcroutes` / `gwctl describe grpcroutes` with HOSTNAMES, PARENT REFS, ACCEPTED, RESOLVED columns
- Topology relations (GRPCRoute → parent Gateways, backendRefs incl. RequestMirror filters, Namespace)
- `--for grpcroute/...` filtering
- Inherited/effective policy calculation and ReferenceGrant validation
- `-o graph` rendering (GRPCRoutes get the same rank treatment as HTTPRoutes)

To keep the follow-up TLSRoute and ListenerSet PRs small, code that previously assumed HTTPRoute now iterates over all supported Route kinds via `common.RouteGKs` and a kind-agnostic `RouteNode` accessor, and the Gateway wide-output column was renamed `HTTPROUTES` → `ROUTES` (it now counts all attached Routes).

Two behavior notes beyond the new resource type:

- Resource fetches done for graph expansion now tolerate resource types unknown to the server, so clusters without the GRPCRoute CRD installed keep working (a user explicitly running `gwctl get grpcroutes` still gets the usual error).
- The RESOLVED column of Route tables previously recomputed the ACCEPTED status due to a copy/paste slip; the shared `routeAcceptedAndResolvedStatus` helper fixes it to summarize `ResolvedRefs` conditions.

**Which issue(s) this PR fixes**:

Part of #120 (GRPCRoute only; TLSRoute and ListenerSet will follow in separate PRs)

**Generative AI Usage Disclosure**

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

*AI Tools used:*
Claude Code

*How they were used:*
Code generation, test authoring, and golden-file updates across the PR, done under the author's direction and review. All unit and integration tests pass locally (`go test ./...`), and `gofmt`/`go vet`/`golangci-lint` are clean.