### PR TITLE
feat: add watch support to get command

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -17,13 +17,20 @@ limitations under the License.
 package get
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/utils/clock"
@@ -73,6 +80,7 @@ func NewCmd(factory common.Factory, iostreams genericiooptions.IOStreams, isDesc
 	if !isDescribe {
 		printableAllowedFormats := strings.Join(printer.AllowedOutputFormatsForHelp(), ",")
 		cmd.Flags().StringVarP(&flags.outputFormat, "output", "o", "", fmt.Sprintf("Output format. Must be one of: %v", printableAllowedFormats))
+		cmd.Flags().BoolVarP(&flags.watch, "watch", "w", false, "After listing/getting the requested object, watch for changes.")
 
 		flags.forFlag.AddFlag(cmd.Flags())
 	}
@@ -84,6 +92,7 @@ func NewCmd(factory common.Factory, iostreams genericiooptions.IOStreams, isDesc
 type getFlags struct {
 	resourceBuilderFlags *genericclioptions.ResourceBuilderFlags
 	outputFormat         string
+	watch                bool
 	forFlag              gwctlflags.ForFlag
 }
 
@@ -105,6 +114,7 @@ func (f *getFlags) ToOptions(args []string, factory common.Factory, iostreams ge
 		IOStreams:     iostreams,
 		allNamespaces: *f.resourceBuilderFlags.AllNamespaces,
 		labelSelector: *f.resourceBuilderFlags.LabelSelector,
+		watch:         f.watch,
 	}
 
 	var err error
@@ -123,6 +133,9 @@ func (f *getFlags) ToOptions(args []string, factory common.Factory, iostreams ge
 	if err != nil {
 		return nil, err
 	}
+	if err := o.validateWatch(); err != nil {
+		return nil, err
+	}
 
 	return o, nil
 }
@@ -136,6 +149,7 @@ type getOptions struct {
 	namespace     string
 	labelSelector string
 	output        printer.OutputFormat
+	watch         bool
 
 	resourceTypes []string
 	hasPolicy     bool
@@ -145,6 +159,10 @@ type getOptions struct {
 }
 
 func (o *getOptions) Run(args []string) error {
+	if o.watch {
+		return o.watchResources(args)
+	}
+
 	needsExtensions := o.isDescribe || o.output == printer.OutputFormatWide || o.output == printer.OutputFormatGraph
 
 	// Initialize PolicyManager if needed (by either non-policy path extensions or policy path)
@@ -186,25 +204,14 @@ func (o *getOptions) Run(args []string) error {
 			sources = append(sources, &unstructured.Unstructured{Object: obj})
 		}
 
-		builder := topology.NewBuilder(common.NewDefaultGroupKindFetcher(o.factory)).StartFrom(sources)
+		var graph *topology.Graph
 		if needsExtensions {
-			builder = builder.UseRelationships(topologygw.AllRelations)
+			graph, err = o.buildExtendedGraph(sources, pm)
+		} else {
+			graph, err = topology.NewBuilder(common.NewDefaultGroupKindFetcher(o.factory)).StartFrom(sources).Build()
 		}
-		graph, err := builder.Build()
 		if err != nil {
 			return err
-		}
-
-		if needsExtensions {
-			err := extension.ExecuteAll(graph, //nolint:govet
-				directlyattachedpolicy.NewExtension(pm),
-				gatewayeffectivepolicy.NewExtension(),
-				refgrantvalidator.NewExtension(refgrantvalidator.NewDefaultReferenceGrantFetcher(o.factory)),
-				notfoundrefvalidator.NewExtension(),
-			)
-			if err != nil {
-				return err
-			}
 		}
 
 		if o.output == printer.OutputFormatGraph {
@@ -232,6 +239,217 @@ func (o *getOptions) Run(args []string) error {
 	}
 
 	return o.printNodes(allNodes)
+}
+
+func (o *getOptions) validateWatch() error {
+	if !o.watch {
+		return nil
+	}
+	if o.isDescribe {
+		return fmt.Errorf("--watch is not supported with describe; use get instead")
+	}
+
+	typeCount := len(o.resourceTypes)
+	if o.hasPolicy {
+		typeCount++
+	}
+	if o.hasPolicyCRD {
+		typeCount++
+	}
+	if typeCount > 1 {
+		return fmt.Errorf("you may only specify a single resource type when watching")
+	}
+	if o.hasPolicy || o.hasPolicyCRD {
+		return fmt.Errorf("watch is not supported for policy/policycrd types")
+	}
+	if o.output != printer.OutputFormatTable && o.output != printer.OutputFormatWide {
+		return fmt.Errorf("--watch is not supported with output format %q", o.output)
+	}
+	return nil
+}
+
+func (o *getOptions) watchResources(args []string) error {
+	var pm *policymanager.PolicyManager
+	if o.output == printer.OutputFormatWide {
+		pm = policymanager.New(common.NewDefaultGroupKindFetcher(o.factory))
+		if err := pm.Init(); err != nil {
+			return err
+		}
+	}
+
+	nonPolicyArgs := make([]string, len(args))
+	nonPolicyArgs[0] = strings.Join(o.resourceTypes, ",")
+	copy(nonPolicyArgs[1:], args[1:])
+
+	result := o.factory.NewBuilder().
+		Unstructured().
+		NamespaceParam(o.namespace).DefaultNamespace().AllNamespaces(o.allNamespaces).
+		ResourceTypeOrNameArgs(true, nonPolicyArgs...).
+		SingleResourceType().
+		LabelSelectorParam(o.labelSelector).
+		Latest().
+		ContinueOnError().
+		Do()
+	if err := result.Err(); err != nil {
+		return err
+	}
+	if _, err := result.Infos(); err != nil {
+		return err
+	}
+
+	obj, err := result.Object()
+	if err != nil {
+		return err
+	}
+	objects, resourceVersion, err := extractInitialObjects(obj)
+	if err != nil {
+		return err
+	}
+	skipInitialAdded := !meta.IsListType(obj)
+
+	p := &printer.TablePrinter{PrinterOptions: printer.PrinterOptions{
+		OutputFormat:  o.output,
+		Clock:         clock.RealClock{},
+		AllNamespaces: o.allNamespaces,
+	}}
+	nodes, err := o.buildWatchNodes(objects, pm)
+	if err != nil {
+		return err
+	}
+	for _, node := range topology.SortedNodes(nodes) {
+		if err := p.PrintNode(node, o.Out); err != nil {
+			return err
+		}
+	}
+	if err := p.FlushWatch(o.Out); err != nil {
+		return err
+	}
+
+	watcher, err := result.Watch(resourceVersion)
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				fmt.Fprintln(o.ErrOut, "server closed the watch stream; exiting")
+				return nil
+			}
+
+			switch event.Type {
+			case watch.Bookmark:
+				if skipInitialAdded && isInitialEventsEndBookmark(event.Object) {
+					// A named resource can disappear between the initial get and
+					// the watch-list snapshot, which ends without an ADDED event.
+					skipInitialAdded = false
+				}
+			case watch.Added, watch.Modified, watch.Deleted:
+				if skipInitialAdded {
+					// The first event on a named-resource watch is the
+					// synthetic ADDED for the object already printed above.
+					skipInitialAdded = false
+					if event.Type == watch.Added {
+						continue
+					}
+				}
+				nodes, err := o.buildWatchNodes([]runtime.Object{event.Object}, pm)
+				if err != nil {
+					return err
+				}
+				for _, node := range nodes {
+					if err := p.PrintNode(node, o.Out); err != nil {
+						return err
+					}
+				}
+				if err := p.FlushWatch(o.Out); err != nil {
+					return err
+				}
+			case watch.Error:
+				return apierrors.FromObject(event.Object)
+			}
+		}
+	}
+}
+
+// buildExtendedGraph builds a topology graph from sources using all gateway
+// relationships and runs the full set of extensions over it.
+func (o *getOptions) buildExtendedGraph(sources []*unstructured.Unstructured, pm *policymanager.PolicyManager) (*topology.Graph, error) {
+	graph, err := topology.NewBuilder(common.NewDefaultGroupKindFetcher(o.factory)).
+		StartFrom(sources).
+		UseRelationships(topologygw.AllRelations).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	if err := extension.ExecuteAll(graph, //nolint:govet
+		directlyattachedpolicy.NewExtension(pm),
+		gatewayeffectivepolicy.NewExtension(),
+		refgrantvalidator.NewExtension(refgrantvalidator.NewDefaultReferenceGrantFetcher(o.factory)),
+		notfoundrefvalidator.NewExtension(),
+	); err != nil {
+		return nil, err
+	}
+	return graph, nil
+}
+
+func extractInitialObjects(obj runtime.Object) ([]runtime.Object, string, error) {
+	if !meta.IsListType(obj) {
+		return []runtime.Object{obj}, "0", nil
+	}
+
+	resourceVersion, err := meta.NewAccessor().ResourceVersion(obj)
+	if err != nil {
+		return nil, "", err
+	}
+	objects, err := meta.ExtractList(obj)
+	if err != nil {
+		return nil, "", err
+	}
+	return objects, resourceVersion, nil
+}
+
+func isInitialEventsEndBookmark(obj runtime.Object) bool {
+	if obj == nil {
+		return false
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return false
+	}
+	return accessor.GetAnnotations()[metav1.InitialEventsAnnotationKey] == "true"
+}
+
+func (o *getOptions) buildWatchNodes(objects []runtime.Object, pm *policymanager.PolicyManager) ([]*topology.Node, error) {
+	sources := make([]*unstructured.Unstructured, 0, len(objects))
+	for _, object := range objects {
+		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(object)
+		if err != nil {
+			return nil, err
+		}
+		sources = append(sources, &unstructured.Unstructured{Object: obj})
+	}
+
+	if o.output != printer.OutputFormatWide {
+		nodes := make([]*topology.Node, 0, len(sources))
+		for _, source := range sources {
+			nodes = append(nodes, &topology.Node{Object: source})
+		}
+		return nodes, nil
+	}
+
+	graph, err := o.buildExtendedGraph(sources, pm)
+	if err != nil {
+		return nil, err
+	}
+	return graph.Sources, nil
 }
 
 func (o *getOptions) collectPolicyNodes(pm *policymanager.PolicyManager, args []string) ([]*topology.Node, error) {

--- a/cmd/get/get_test.go
+++ b/cmd/get/get_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/restmapper"
+
+	"sigs.k8s.io/gwctl/pkg/printer"
+)
+
+var errWatchBuilderCallback = errors.New("watch builder callback should not be called")
+
+type watchTestFactory struct{}
+
+func (watchTestFactory) NewBuilder() *resource.Builder {
+	return resource.NewFakeBuilder(
+		func(schema.GroupVersion) (resource.RESTClient, error) {
+			return nil, errWatchBuilderCallback
+		},
+		func() (meta.RESTMapper, error) {
+			return nil, errWatchBuilderCallback
+		},
+		func() (restmapper.CategoryExpander, error) {
+			return resource.FakeCategoryExpander, nil
+		},
+	)
+}
+
+func (watchTestFactory) KubeConfigNamespace() (string, bool, error) {
+	return "default", false, nil
+}
+
+func TestValidateWatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		options getOptions
+		wantErr string
+	}{
+		{
+			name: "table output",
+			options: getOptions{
+				watch:         true,
+				resourceTypes: []string{"gateways"},
+			},
+		},
+		{
+			name: "wide output",
+			options: getOptions{
+				watch:         true,
+				output:        printer.OutputFormatWide,
+				resourceTypes: []string{"gateways"},
+			},
+		},
+		{
+			name: "json output",
+			options: getOptions{
+				watch:         true,
+				output:        printer.OutputFormatJSON,
+				resourceTypes: []string{"gateways"},
+			},
+			wantErr: `--watch is not supported with output format "json"`,
+		},
+		{
+			name: "multiple resource types",
+			options: getOptions{
+				watch:         true,
+				resourceTypes: []string{"gateways", "httproutes"},
+			},
+			wantErr: "you may only specify a single resource type when watching",
+		},
+		{
+			name: "policy type",
+			options: getOptions{
+				watch:     true,
+				hasPolicy: true,
+			},
+			wantErr: "watch is not supported for policy/policycrd types",
+		},
+		{
+			name: "policy and another type",
+			options: getOptions{
+				watch:         true,
+				resourceTypes: []string{"gateways"},
+				hasPolicy:     true,
+			},
+			wantErr: "you may only specify a single resource type when watching",
+		},
+		{
+			name: "describe",
+			options: getOptions{
+				watch:         true,
+				isDescribe:    true,
+				resourceTypes: []string{"gateways"},
+			},
+			wantErr: "--watch is not supported with describe; use get instead",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.options.validateWatch()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateWatch() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateWatch() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestWatchResourcesRejectsExpandedCategory(t *testing.T) {
+	o := getOptions{
+		factory:       watchTestFactory{},
+		namespace:     "default",
+		output:        printer.OutputFormatTable,
+		watch:         true,
+		resourceTypes: []string{"all"},
+	}
+	if err := o.validateWatch(); err != nil {
+		t.Fatalf("validateWatch() error = %v, want nil", err)
+	}
+
+	err := o.watchResources([]string{"all"})
+	if !errors.Is(err, resource.ErrMultipleResourceTypes) {
+		t.Fatalf("watchResources() error = %v, want %v", err, resource.ErrMultipleResourceTypes)
+	}
+}
+
+func TestNewCmdRegistersWatchOnlyForGet(t *testing.T) {
+	getCmd := NewCmd(nil, genericiooptions.IOStreams{}, false)
+	watchFlag := getCmd.Flags().Lookup("watch")
+	if watchFlag == nil {
+		t.Fatal("get command does not register --watch")
+	}
+	if watchFlag.Shorthand != "w" {
+		t.Fatalf("--watch shorthand = %q, want %q", watchFlag.Shorthand, "w")
+	}
+
+	describeCmd := NewCmd(nil, genericiooptions.IOStreams{}, true)
+	if describeCmd.Flags().Lookup("watch") != nil {
+		t.Fatal("describe command unexpectedly registers --watch")
+	}
+}

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -91,6 +91,8 @@ type TablePrinter struct {
 	table               *Table
 	unknownTablePrinter printers.ResourcePrinter
 	curType             string
+	watchHeaderPrinted  bool
+	watchColumnWidths   []int
 }
 
 func (p *TablePrinter) PrintNode(node *topology.Node, w io.Writer) error {
@@ -99,6 +101,25 @@ func (p *TablePrinter) PrintNode(node *topology.Node, w io.Writer) error {
 
 func (p *TablePrinter) Flush(w io.Writer) error {
 	return p.checkTypeChange("", w)
+}
+
+func (p *TablePrinter) FlushWatch(w io.Writer) error {
+	if p.table == nil {
+		return nil
+	}
+	defer func() { p.table.Rows = nil }()
+
+	if !p.watchHeaderPrinted {
+		if err := p.table.Write(w, 0); err != nil {
+			return err
+		}
+		p.watchHeaderPrinted = true
+		p.watchColumnWidths = p.table.columnWidths()
+		return nil
+	}
+
+	p.watchColumnWidths = mergeColumnWidths(p.watchColumnWidths, p.table.columnWidths())
+	return p.table.writeRows(w, 0, p.watchColumnWidths)
 }
 
 func (p *TablePrinter) printUnknown(node *topology.Node, w io.Writer) error {

--- a/pkg/printer/utils.go
+++ b/pkg/printer/utils.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"unicode/utf8"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -119,6 +120,63 @@ func (t *Table) Write(w io.Writer, indent int) error {
 		}
 	}
 	return tw.Flush()
+}
+
+func (t *Table) columnWidths() []int {
+	widths := make([]int, len(t.ColumnNames))
+	for i, columnName := range t.ColumnNames {
+		widths[i] = utf8.RuneCountInString(columnName)
+	}
+
+	for _, row := range t.Rows {
+		for i, value := range row {
+			if i >= len(widths) {
+				widths = append(widths, 0)
+			}
+			widths[i] = max(widths[i], utf8.RuneCountInString(value))
+		}
+	}
+	return widths
+}
+
+func mergeColumnWidths(current, next []int) []int {
+	widths := append([]int{}, current...)
+	if len(next) > len(widths) {
+		widths = append(widths, make([]int, len(next)-len(widths))...)
+	}
+	for i, width := range next {
+		widths[i] = max(widths[i], width)
+	}
+	return widths
+}
+
+// writeRows writes data rows using column widths established by an earlier
+// table write. Watch output is written incrementally, so the standard library
+// tabwriter cannot retain those widths after it is flushed.
+func (t *Table) writeRows(w io.Writer, indent int, columnWidths []int) error {
+	for _, row := range t.Rows {
+		row = t.indentRow(row, indent)
+
+		var line strings.Builder
+		for i, value := range row {
+			line.WriteString(value)
+			if i == len(row)-1 {
+				continue
+			}
+
+			width := utf8.RuneCountInString(value)
+			if i < len(columnWidths) {
+				width = max(width, columnWidths[i])
+			}
+			line.WriteString(strings.Repeat(" ", width-utf8.RuneCountInString(value)+2))
+		}
+		line.WriteByte('\n')
+
+		if _, err := io.WriteString(w, line.String()); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // indentRow will add 'indent' spaces to the beginning of the row.

--- a/pkg/printer/watch_test.go
+++ b/pkg/printer/watch_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printer //nolint:revive
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"sigs.k8s.io/gwctl/pkg/common"
+	"sigs.k8s.io/gwctl/pkg/topology"
+)
+
+func TestTablePrinterFlushWatch(t *testing.T) {
+	node := testData(t)[common.GatewayGK][0]
+	secondNode := &topology.Node{Object: node.Object.DeepCopy()}
+	secondNode.Object.SetName("g")
+
+	p := &TablePrinter{}
+	out := &bytes.Buffer{}
+	if err := p.PrintNode(node, out); err != nil {
+		t.Fatalf("PrintNode() error = %v", err)
+	}
+	if err := p.FlushWatch(out); err != nil {
+		t.Fatalf("FlushWatch() error = %v", err)
+	}
+	if err := p.PrintNode(secondNode, out); err != nil {
+		t.Fatalf("PrintNode() error = %v", err)
+	}
+	if err := p.FlushWatch(out); err != nil {
+		t.Fatalf("FlushWatch() error = %v", err)
+	}
+
+	// The header is written once, with the initial list. A later, shorter name
+	// must still use the initial list's column width.
+	wantOut := `
+NAME       CLASS            ADDRESSES                   PORTS  PROGRAMMED  AGE
+gateway-1  gateway-class-1  10.0.0.1,10.0.0.2 + 1 more  80     True        <unknown>
+g          gateway-class-1  10.0.0.1,10.0.0.2 + 1 more  80     True        <unknown>
+`
+
+	got := common.MultiLine(out.String())
+	want := common.MultiLine(strings.TrimPrefix(wantOut, "\n"))
+
+	if diff := cmp.Diff(want, got, common.MultiLineTransformer); diff != "" {
+		t.Fatalf("Unexpected diff:\n\ngot =\n\n%v\n\nwant =\n\n%v\n\ndiff (-want, +got) =\n\n%v",
+			got, want, common.MultiLine(diff))
+	}
+}

--- a/test/integration/get_test.go
+++ b/test/integration/get_test.go
@@ -22,6 +22,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	cmdget "sigs.k8s.io/gwctl/cmd/get"
@@ -30,6 +33,151 @@ import (
 
 //go:embed testdata/sample1.yaml
 var testdataSample1 string
+
+func TestGetWatch(t *testing.T) {
+	factory := NewTestFactory(t, testdataSample1)
+	factory.namespace = "default"
+	factory.setWatchEvents(t,
+		watch.Event{Type: watch.Added, Object: watchGateway("gateway-added")},
+		watch.Event{Type: watch.Modified, Object: watchGateway("gateway-modified")},
+		watch.Event{Type: watch.Deleted, Object: watchGateway("gateway-deleted")},
+	)
+
+	iostreams, _, out, errOut := genericiooptions.NewTestIOStreams()
+	cmd := cmdget.NewCmd(factory, iostreams, false)
+	cmd.SetArgs([]string{"gateways", "--watch"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := out.String()
+	if count := strings.Count(got, "NAME"); count != 1 {
+		t.Fatalf("header count = %d, want 1\noutput:\n%s", count, got)
+	}
+	for _, name := range []string{"gateway-3", "gateway-added", "gateway-modified", "gateway-deleted"} {
+		if !strings.Contains(got, name) {
+			t.Fatalf("output does not contain %q:\n%s", name, got)
+		}
+	}
+	if !strings.Contains(errOut.String(), "server closed the watch stream") {
+		t.Fatalf("stderr does not report the server closing the watch:\n%s", errOut.String())
+	}
+}
+
+func TestGetWatchNamedResource(t *testing.T) {
+	factory := NewTestFactory(t, testdataSample1)
+	factory.namespace = "default"
+	factory.setWatchEvents(t,
+		watch.Event{Type: watch.Added, Object: watchGateway("gateway-3")},
+		watch.Event{Type: watch.Modified, Object: watchGateway("gateway-modified")},
+	)
+
+	iostreams, _, out, _ := genericiooptions.NewTestIOStreams()
+	cmd := cmdget.NewCmd(factory, iostreams, false)
+	cmd.SetArgs([]string{"gateways", "gateway-3", "--watch"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := out.String()
+	if count := strings.Count(got, "gateway-3"); count != 1 {
+		t.Fatalf("gateway-3 row count = %d, want 1\noutput:\n%s", count, got)
+	}
+	if !strings.Contains(got, "gateway-modified") {
+		t.Fatalf("output does not contain the modified resource:\n%s", got)
+	}
+}
+
+// TestGetWatchNamedResourceFirstEventNotAdded ensures the synthetic-ADDED
+// suppression on a named-resource watch is disarmed by the first event of any
+// type, not only by an ADDED event. Otherwise a genuine ADDED arriving after
+// a first MODIFIED/DELETED would be silently dropped.
+func TestGetWatchNamedResourceFirstEventNotAdded(t *testing.T) {
+	factory := NewTestFactory(t, testdataSample1)
+	factory.namespace = "default"
+	factory.setWatchEvents(t,
+		watch.Event{Type: watch.Modified, Object: watchGateway("gateway-modified")},
+		watch.Event{Type: watch.Added, Object: watchGateway("gateway-added")},
+	)
+
+	iostreams, _, out, _ := genericiooptions.NewTestIOStreams()
+	cmd := cmdget.NewCmd(factory, iostreams, false)
+	cmd.SetArgs([]string{"gateways", "gateway-3", "--watch"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := out.String()
+	for _, name := range []string{"gateway-modified", "gateway-added"} {
+		if !strings.Contains(got, name) {
+			t.Fatalf("output does not contain %q:\n%s", name, got)
+		}
+	}
+}
+
+func TestGetWatchNamedResourceInitialEventsEndBookmark(t *testing.T) {
+	factory := NewTestFactory(t, testdataSample1)
+	factory.namespace = "default"
+	bookmark := watchGateway("gateway-3")
+	bookmark.SetAnnotations(map[string]string{metav1.InitialEventsAnnotationKey: "true"})
+	factory.setWatchEvents(t,
+		watch.Event{Type: watch.Bookmark, Object: bookmark},
+		watch.Event{Type: watch.Added, Object: watchGateway("gateway-added")},
+	)
+
+	iostreams, _, out, _ := genericiooptions.NewTestIOStreams()
+	cmd := cmdget.NewCmd(factory, iostreams, false)
+	cmd.SetArgs([]string{"gateways", "gateway-3", "--watch"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "gateway-added") {
+		t.Fatalf("output does not contain the added resource:\n%s", got)
+	}
+}
+
+func TestGetWatchWide(t *testing.T) {
+	factory := NewTestFactory(t, testdataSample1)
+	factory.namespace = "default"
+	factory.setWatchEvents(t, watch.Event{Type: watch.Added, Object: watchGateway("gateway-added")})
+
+	iostreams, _, out, _ := genericiooptions.NewTestIOStreams()
+	cmd := cmdget.NewCmd(factory, iostreams, false)
+	cmd.SetArgs([]string{"gateways", "--watch", "-o", "wide"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "POLICIES") || !strings.Contains(got, "HTTPROUTES") {
+		t.Fatalf("wide output does not contain its additional columns:\n%s", got)
+	}
+	if !strings.Contains(got, "gateway-added") {
+		t.Fatalf("output does not contain the added resource:\n%s", got)
+	}
+}
+
+func watchGateway(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "default",
+		},
+		"spec": map[string]any{
+			"gatewayClassName": "foo-com-external-gateway-class",
+			"listeners": []any{
+				map[string]any{
+					"name":     "http",
+					"port":     80,
+					"protocol": "HTTP",
+				},
+			},
+		},
+	}}
+}
 
 func TestGet(t *testing.T) {
 	factory := NewTestFactory(t, testdataSample1)

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -32,11 +32,14 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery/cached/memory"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest/fake"
+	restclientwatch "k8s.io/client-go/rest/watch"
 	"k8s.io/client-go/restmapper"
 	clientgotesting "k8s.io/client-go/testing"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -50,6 +53,7 @@ type TestFactory struct {
 	namespace          string
 	unstructuredClient resource.RESTClient
 	restMapper         meta.RESTMapper
+	watchResponse      []byte
 }
 
 func NewTestFactory(t *testing.T, yamls ...string) *TestFactory {
@@ -68,11 +72,25 @@ func NewTestFactory(t *testing.T, yamls ...string) *TestFactory {
 
 	restMapper := mustRestMapper(t, infos)
 
-	f := &TestFactory{
-		unstructuredClient: mustFakeRestClient(t, infos, restMapper),
-		restMapper:         restMapper,
-	}
+	f := &TestFactory{restMapper: restMapper}
+	f.unstructuredClient = f.mustFakeRestClient(t, infos)
 	return f
+}
+
+// setWatchEvents encodes events in the same wire format the API server uses
+// for watch streams, so they are decoded by client-go's real watch decoder.
+func (f *TestFactory) setWatchEvents(t *testing.T, events ...watch.Event) {
+	t.Helper()
+
+	codec := unstructured.NewJSONFallbackEncoder(scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...))
+	buf := &bytes.Buffer{}
+	encoder := restclientwatch.NewEncoder(streaming.NewEncoder(buf, codec), codec)
+	for i := range events {
+		if err := encoder.Encode(&events[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f.watchResponse = buf.Bytes()
 }
 
 func (f *TestFactory) NewBuilder() *resource.Builder {
@@ -177,8 +195,8 @@ func mustRestMapper(t *testing.T, infos []*resource.Info) meta.RESTMapper {
 	return restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscoveryClient)
 }
 
-func mustFakeRestClient(t *testing.T, infos []*resource.Info, restMapper meta.RESTMapper) *fake.RESTClient {
-	resourcesByPath := loadResourcesByPath(t, infos, restMapper)
+func (f *TestFactory) mustFakeRestClient(t *testing.T, infos []*resource.Info) *fake.RESTClient {
+	resourcesByPath := loadResourcesByPath(t, infos, f.restMapper)
 
 	codec := unstructured.NewJSONFallbackEncoder(scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...))
 	roundTripper := func(req *http.Request) (*http.Response, error) {
@@ -191,6 +209,16 @@ func mustFakeRestClient(t *testing.T, infos []*resource.Info, restMapper meta.RE
 		if method != "GET" {
 			t.Fatalf("request url: %+v, and request: %+v", req.URL, req)
 			return nil, nil
+		}
+		if req.URL.Query().Get("watch") == "true" {
+			if f.watchResponse == nil {
+				t.Fatalf("unexpected watch request: %+v", req.URL)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     cmdtesting.DefaultHeader(),
+				Body:       io.NopCloser(bytes.NewReader(f.watchResponse)),
+			}, nil
 		}
 
 		responseBody := resourcesByPath[pathAndQuery]


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds support for watching a single resource type with `gwctl get --watch` / `-w`, with an initial list followed by watch events.

Key changes:
- Adds `--watch` / `-w` to `gwctl get`, printing the initial list followed by ADDED, MODIFIED, and DELETED events
- Supports table and wide output only; rejects json, yaml, and graph output while watching
- Rejects multiple resolved resource types and virtual policy/policycrd types for watch requests
- Uses standard-library interrupt handling and exits cleanly on SIGINT or SIGTERM
- Preserves table column alignment across incrementally printed watch events without adding a direct external dependency
- Adds unit and integration coverage for watch behavior, including named-resource and initial-events bookmark handling

**Which issue(s) this PR fixes**:
Fixes #110

**Does this PR introduce a user-facing change?**:
```release-note
Get command now supports `--watch` / `-w` for table and wide output, with an initial list followed by ADDED, MODIFIED, and DELETED events.
```